### PR TITLE
chore(stuff): add grunt/bower/npm/karma infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/bower_components
+/node_modules

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,39 @@
+var bower = require('bower');
+
+module.exports = function(grunt) {
+  grunt.loadNpmTasks('grunt-karma');
+
+  grunt.registerTask('bower', 'Install Bower packages.', function () {
+    var done = this.async();
+
+    bower.commands.install()
+      .on('log', function (result) {
+        grunt.log.ok('bower: ' + result.id + ' ' + result.data.endpoint.name);
+      })
+      .on('error', grunt.fail.warn.bind(grunt.fail))
+      .on('end', done);
+  });
+
+  grunt.initConfig({
+    karma: {
+      options: {
+        configFile: 'karma.conf.js'
+      },
+      watch: {
+        background: true
+      },
+      once: {
+        singleRun: true
+      },
+      travis: {
+        singleRun: true,
+        browsers: ['PhantomJS', 'Firefox']
+      }
+    }
+  });
+
+  grunt.registerTask('default', ['bower', 'test']);
+  grunt.registerTask('test', ['bower', 'karma:once']);
+  grunt.registerTask('test:watch', ['bower', 'karma:watch']);
+  grunt.registerTask('test:travis', ['bower', 'karma:travis']);
+};

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,23 @@
+{
+  "name": "ui-select",
+  "version": "0.0.1-SNAPSHOT",
+  "homepage": "https://github.com/angular-ui/ui-select",
+  "authors": [
+    "AngularUI"
+  ],
+  "description": "AngularJS-native implementation of Select2",
+  "main": "select.js",
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "angular": "~1.0.8",
+    "angular-mocks": "~1.0.8",
+    "jquery": "~2.0.3"
+  }
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,72 @@
+// Karma configuration
+// Generated on Wed Nov 06 2013 18:40:09 GMT-0500 (EST)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path, that will be used to resolve files and exclude
+    basePath: '',
+
+
+    // frameworks to use
+    frameworks: ['jasmine'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      'bower_components/jquery/jquery.js',
+      'bower_components/angular/angular.js',
+      'bower_components/angular-mocks/angular-mocks.js',
+      'select.js',
+      'test/**/*.spec.js'
+    ],
+
+
+    // list of files to exclude
+    exclude: [
+      
+    ],
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress', 'junit', 'growl', 'coverage'
+    reporters: ['progress'],
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+
+    // Start these browsers, currently available:
+    // - Chrome
+    // - ChromeCanary
+    // - Firefox
+    // - Opera (has to be installed with `npm install karma-opera-launcher`)
+    // - Safari (only Mac; has to be installed with `npm install karma-safari-launcher`)
+    // - PhantomJS
+    // - IE (only Windows; has to be installed with `npm install karma-ie-launcher`)
+    browsers: ['Chrome'],
+
+
+    // If browser does not capture in given timeout [ms], kill it
+    captureTimeout: 60000,
+
+
+    // Continuous Integration mode
+    // if true, it capture browsers, run tests and exit
+    singleRun: false
+  });
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "ui-select",
+  "version": "0.1.0-SNAPSHOT",
+  "description": "AngularJS-native implementation of Select2",
+  "main": "select.js",
+  "dependencies": {
+    "grunt": "~0.4.1",
+    "grunt-karma": "~0.6.2",
+    "karma": "~0.10.4",
+    "karma-chrome-launcher": "~0.1.0",
+    "karma-firefox-launcher": "~0.1.0",
+    "karma-jasmine": "~0.1.3",
+    "karma-phantomjs-launcher": "~0.1.0"
+  },
+  "devDependencies": {
+    "karma": "~0.10.4",
+    "grunt": "~0.4.1",
+    "grunt-karma": "~0.6.2",
+    "bower": "~1.2.7"
+  },
+  "scripts": {
+    "test": "grunt test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular-ui/ui-select"
+  },
+  "author": "AngularUI",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/angular-ui/ui-select/issues"
+  }
+}

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -1,0 +1,5 @@
+describe('select', function() {
+  it('', function() {
+  });
+});
+


### PR DESCRIPTION
There isn't much to work with yet in terms of actually writing tests, but this patch provides an infrastructure to easily begin writing tests when refactoring.
