### PR TITLE
Retain keyboard focus after closing the dropdown.

### DIFF
--- a/dist/select.css
+++ b/dist/select.css
@@ -55,3 +55,8 @@
   max-height: 200px;
   overflow-x: hidden;
 }
+
+.ui-select-bootstrap .form-control {
+    -webkit-transition: none;
+    transition: none;
+}

--- a/dist/select.js
+++ b/dist/select.js
@@ -199,6 +199,12 @@ angular.module('ui.select', [])
     if (ctrl.open) {
       _resetSearchInput();
       ctrl.open = false;
+
+      // Give it time to appear before focus
+      $timeout(function () {
+        var _selectButton = $element.querySelectorAll("button.ui-select-match");
+          _selectButton[0].focus();
+      });
     }
   };
 


### PR DESCRIPTION
Fixes #46.

The fix does two things. First, it actively sets focus back to the button after closing the dropdown. To do this, it uses $timeout with a zero timeout value to give angular time to show the button before changing focus to it. This is the same as was done previously when showing the dropdown.

There is however a second problem: bootstrap defines a transition for form_control. This means that it takes some time before the button is shown. This means that when the timeout fires and focus() is called, the button is still hidden and thus cannot be focused.

To work around the second problem, we can either use a slightly longer timeout (a few 100ms), or we can disable the transitions. I have chosen to disable the transitions, since the timeout feels "ugly". This is done in  the patch to select.css.
