### PR TITLE
Include uiSelectMinErr in uiSelect directive

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -280,8 +280,8 @@ angular.module('ui.select', [])
 }])
 
 .directive('uiSelect',
-  ['$document', 'uiSelectConfig',
-  function($document, uiSelectConfig) {
+  ['$document', 'uiSelectConfig', 'uiSelectMinErr', 
+  function($document, uiSelectConfig, uiSelectMinErr) {
 
   return {
     restrict: 'EA',


### PR DESCRIPTION
Fixes an not defined error being thrown when the transcludeFn is unable to find `.ui-select-match`: https://github.com/angular-ui/ui-select/blob/master/src/select.js#L360
