### PR TITLE
Add specs for error cases

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -55,6 +55,10 @@ angular.module('ui.select', [])
    * keyIdentifier = undefined
    */
   self.parse = function(expression) {
+    if (!expression) {
+      throw uiSelectMinErr('repeat', "Expected 'repeat' expression.");
+    }
+
     var match = expression.match(/^\s*([\s\S]+?)\s+in\s+([\s\S]+?)(?:\s+track\s+by\s+([\s\S]+?))?\s*$/);
 
     if (!match) {

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -182,4 +182,33 @@ describe('ui-select tests', function() {
     expect(el.scope().$select.selected).toEqual('false');
     expect(getMatchLabel(el)).toEqual('false');
   });
-});
+
+  it('should throw when no ui-select-choices found', function() {
+    expect(function() {
+      compileTemplate(
+        '<ui-select ng-model="selection"> \
+          <ui-select-match></ui-select-match> \
+        </ui-select>'
+      );
+    }).toThrow(new Error('[ui.select:transcluded] Expected 1 .ui-select-choices but got \'0\'.'));
+  });
+
+  it('should throw when no repeat attribute is provided to ui-select-choices', function() {
+    expect(function() {
+      compileTemplate(
+        '<ui-select ng-model="selection"> \
+          <ui-select-choices></ui-select-choices> \
+        </ui-select>'
+      );
+    }).toThrow(new Error('[ui.select:repeat] Expected \'repeat\' expression.'));
+  });
+
+  it('should throw when no ui-select-match found', function() {
+    expect(function() {
+      compileTemplate(
+        '<ui-select ng-model="selection"> \
+          <ui-select-choices repeat="item in items"></ui-select-choices> \
+        </ui-select>'
+      );
+    }).toThrow(new Error('[ui.select:transcluded] Expected 1 .ui-select-match but got \'0\'.'));
+  });});


### PR DESCRIPTION
Add specs for error cases.
Throw error when no `repeat` attribute is provided to directives for which it is expected.
