### PR TITLE
Escape key was not being handled when no items are found in a search.

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -239,7 +239,7 @@ angular.module('ui.select', [])
   _searchInput.on('keydown', function(e) {
     // Keyboard shortcuts are all about the items,
     // does not make sense (and will crash) if ctrl.items is empty
-    if (ctrl.items.length > 0) {
+    if (ctrl.items && ctrl.items.length >= 0) {
       var key = e.which;
 
       $scope.$apply(function() {


### PR DESCRIPTION
My only hesitation with this change is the comment:

 // does not make sense (and will crash) if ctrl.items is empty

I assume that it was referring to a null ctrl.items? I haven't noticed any issues with this change and now it handles the escape key.
