### PR TITLE
Fix issue with focusing search field

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -141,7 +141,7 @@ angular.module('ui.select', [])
       // Give it time to appear before focus
       $timeout(function() {
         _searchInput[0].focus();
-      });
+      }, 10);
     }
   };
 


### PR DESCRIPTION
Using Firefox 30 and IE 8, the search field seems to not get focus the first time the field is clicked. If you click on the field, blur and then click it again, all focus events after the first seem to work (on the same element).
By slightly extending the timeout value, the search field can be made to focus on every click, which seems more user friendly to me.
