### PR TITLE
Reset activeIndex on popup close in case we highlighted another choice without selecting it

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -129,6 +129,10 @@ angular.module('ui.select', [])
   function _resetSearchInput() {
     if (ctrl.resetSearchInput) {
       ctrl.search = EMPTY_SEARCH;
+      //reset activeIndex
+      if (ctrl.selected && ctrl.items.length) {
+        ctrl.activeIndex = ctrl.items.indexOf(ctrl.selected);
+      }
     }
   }
 
@@ -200,10 +204,6 @@ angular.module('ui.select', [])
   // Closes the dropdown
   ctrl.close = function() {
     if (ctrl.open) {
-      //reset activeIndex
-      if (ctrl.selected && ctrl.items.length) {
-        ctrl.activeIndex = ctrl.items.indexOf(ctrl.selected);
-      }
       _resetSearchInput();
       ctrl.open = false;
     }


### PR DESCRIPTION
If we open the popup and select a choice without validating it, this choice will be kept the next time we open the popup. This is not what we want.

This pull request reset the activeIndex by the selected index when we close popup.
