### PR TITLE
style(ngRequired): mark when invalid

### DIFF
--- a/src/select.css
+++ b/src/select.css
@@ -6,6 +6,10 @@
 
 /* Select2 theme */
 
+/* Mark invalid Select2 */
+.ng-dirty.ng-invalid > a.select2-choice {
+    border-color: #D44950;
+}
 
 /* Selectize theme */
 
@@ -17,6 +21,11 @@
 /* Fix dropdown width for Selectize theme */
 .selectize-control > .selectize-dropdown {
   width: 100%;
+}
+
+/* Mark invalid Selectize */
+.ng-dirty.ng-invalid > div.selectize-input {
+    border-color: #D44950;
 }
 
 
@@ -60,4 +69,9 @@
 .ui-select-match.ng-hide-add,
 .ui-select-search.ng-hide-add {
     display: none !important;
+}
+
+/* Mark invalid Bootstrap */
+.ui-select-bootstrap.ng-dirty.ng-invalid > button.btn.ui-select-match {
+    border-color: #D44950;
 }


### PR DESCRIPTION
When using ng-required a red border on control is shown (styles added all 3 themes)

The styles will show only if the control is _dirty_ and _invalid_, so to reproduce it you should first fill values on each field and then press `Clear ng-model`

You can try it with this [plunker](http://plnkr.co/edit/RN9Fry?p=preview)

![screen shot 2014-07-01 at 12 15 59 am](https://cloud.githubusercontent.com/assets/5034942/3439195/3e928638-00df-11e4-8d92-b72984d19146.png)
