### PR TITLE
fix(bower): limit angular version 1.2.0 - 1.2.17 until fix for 1.2.18+ is merged

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,11 +16,11 @@
     "test"
   ],
   "dependencies": {
-    "angular": "~1.2"
+    "angular": "1.2.0 - 1.2.17"
   },
   "devDependencies": {
     "jquery": "~1.11",
-    "angular-sanitize": "~1.2",
-    "angular-mocks": "~1.2"
+    "angular-sanitize": "1.2.0 - 1.2.17",
+    "angular-mocks": "1.2.0 - 1.2.17"
   }
 }


### PR DESCRIPTION
This will solve the failing tests currently on master and will avoid incompatible version of angular installed with bower.
