### PR TITLE
Added miniumResultsForSeach

### DIFF
--- a/examples/select2-bootstrap3.html
+++ b/examples/select2-bootstrap3.html
@@ -117,6 +117,21 @@
         </div>
       </div>
 
+      <div class="form-group">
+        <label class="col-sm-3 control-label">Minimum results for search</label>
+        <div class="col-sm-6">
+
+          <ui-select ng-model="person.selected" theme="select2" class="form-control" minimum-results-for-search="20">
+            <ui-select-match placeholder="Select or search a person in the list...">{{$select.selected.name}}</ui-select-match>
+            <ui-select-choices repeat="item in people | filter: $select.search">
+              <div ng-bind-html="item.name | highlight: $select.search"></div>
+              <small ng-bind-html="item.email | highlight: $select.search"></small>
+            </ui-select-choices>
+          </ui-select>
+
+        </div>
+      </div>
+
     </fieldset>
   </form>
 

--- a/src/select.css
+++ b/src/select.css
@@ -24,6 +24,15 @@
     border-color: #D44950;
 }
 
+ /* Hide select2 search  */
+.select2 .select2-search {
+	display: none;
+}
+
+.select2  .select2-with-searchbox  .select2-search {
+	display: block;
+}
+
 /* Selectize theme */
 
 /* Helper class to show styles when focus */

--- a/src/select.js
+++ b/src/select.js
@@ -127,6 +127,12 @@
     ctrl.resetSearchInput = undefined; // Initialized inside uiSelect directive link function
     ctrl.refreshDelay = undefined; // Initialized inside uiSelectChoices directive link function
 
+    // hide search if minimum results
+    ctrl.minimumResultsForSearch = undefined;
+    ctrl.showSearch = function () {
+      return ctrl.minimumResultsForSearch === null ? true : ctrl.minimumResultsForSearch >= 0 && ctrl.items && ctrl.items.length >= ctrl.minimumResultsForSearch;
+    };
+
     var _searchInput = $element.querySelectorAll('input.ui-select-search');
     if (_searchInput.length !== 1) {
       throw uiSelectMinErr('searchInput', "Expected 1 input.ui-select-search but got '{0}'.", _searchInput.length);
@@ -495,6 +501,10 @@
 
         // See Click everywhere but here event http://stackoverflow.com/questions/12931369
         $document.on('click', onDocumentClick);
+
+        attrs.$observe('minimumResultsForSearch', function () {
+          $select.minimumResultsForSearch = attrs.minimumResultsForSearch !== undefined ? attrs.minimumResultsForSearch : null;
+        });
 
         scope.$on('$destroy', function() {
           $document.off('click', onDocumentClick);

--- a/src/select2/select.tpl.html
+++ b/src/select2/select.tpl.html
@@ -3,12 +3,12 @@
                 'select2-container-disabled': $select.disabled,
                 'select2-container-active': $select.focus }">
   <div class="ui-select-match"></div>
-  <div class="select2-drop select2-with-searchbox select2-drop-active"
-       ng-class="{'select2-display-none': !$select.open}">
+  <div class="select2-drop select2-drop-active"
+       ng-class="{'select2-display-none': !$select.open, 'select2-with-searchbox' : $select.showSearch()}">
     <div class="select2-search">
       <input type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
              class="ui-select-search select2-input"
-             ng-model="$select.search">
+             ng-model="$select.search" />
     </div>
     <div class="ui-select-choices"></div>
   </div>


### PR DESCRIPTION
Added custom attribute 'minimumResultsForSelect' to ui-select directive which will remove the 'select2-with-search' class.

Added styles to hide the search if the 'select2-with-search' class is not applied.

Updated examples to include a case where the search is hidden.

Resolution for Issue #54 
