### PR TITLE
Add line to README for importing the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Check the [examples](https://github.com/angular-ui/ui-select/blob/master/example
 - Inside your HTML add
   - select.js: `<script src="bower_components/angular-ui-select/dist/select.min.js"></script>`
   - select.css: `<link rel="stylesheet" href="bower_components/angular-ui-select/dist/select.min.css">`
+- Add the `ui.select` module as a dependency: `angular.module("myApp", ["ui.select"]);`
 
 ### Bootstrap theme
 


### PR DESCRIPTION
This is an easy step to forget during initial setup. It is helpful 
to not require the user to look through the demo again to get the 
name of the ui-select module.
