### PR TITLE
Prevent '$apply already in progress' error at angular v1.3.0-beta-12+

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -237,7 +237,9 @@
       if (ctrl.open) {
         _resetSearchInput();
         ctrl.open = false;
-        ctrl.focusser[0].focus();
+        $timeout(function(){
+          ctrl.focusser[0].focus();          
+        });
       }
     };
 


### PR DESCRIPTION
Problem was caused by this [commit](https://github.com/angular/angular.js/commit/adcc5a00bf582d2b291c18e99093bb0854f7217c) in angular code. 

I already also send them [a comment](https://github.com/angular/angular.js/pull/8450#discussion_r15726580) with a proposal on how to prevent this.

If they don't fix/change at angular's end, then I'll merge this in couple of days.

Working [plunker](http://plnkr.co/edit/fEiL7rYPZt5Ld6wTuSeX?p=preview)

Closes https://github.com/angular-ui/ui-select/pull/124
