### PR TITLE
Add support for tabindex on focusser input

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -549,6 +549,8 @@
         var $select = ctrls[0];
         var ngModel = ctrls[1];
 
+        var searchInput = element.querySelectorAll('input.ui-select-search');
+
         $select.multiple = angular.isDefined(attrs.multiple);
 
         $select.onSelectCallback = $parse(attrs.onSelect);
@@ -628,7 +630,12 @@
         if(attrs.tabindex){
           //tabindex might be an expression, wait until it contains the actual value before we set the focusser tabindex
           attrs.$observe('tabindex', function(value) {
-            focusser.attr("tabindex", value);
+            //If we are using multiple, add tabindex to the search input 
+            if($select.multiple){
+              searchInput.attr("tabindex", value);
+            } else {
+              focusser.attr("tabindex", value);
+            }
             //Remove the tabindex on the parent so that it is not focusable
             element.removeAttr("tabindex");
           });

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -773,6 +773,7 @@ describe('ui-select tests', function() {
         if (attrs !== undefined) {
             if (attrs.disabled !== undefined) { attrsHtml += ' ng-disabled="' + attrs.disabled + '"'; }
             if (attrs.required !== undefined) { attrsHtml += ' ng-required="' + attrs.required + '"'; }
+            if (attrs.tabindex !== undefined) { attrsHtml += ' tabindex="' + attrs.tabindex + '"'; }
         }
 
         return compileTemplate(
@@ -816,6 +817,31 @@ describe('ui-select tests', function() {
         el.find('.ui-select-match-item').first().find('.ui-select-match-close').click();
         expect(el.scope().$select.selected.length).toBe(1);
         // $timeout.flush();
+    });
+
+    it('should pass tabindex to searchInput', function() {
+      var el = createUiSelectMultiple({tabindex: 5});
+      var searchInput = el.find('.ui-select-search');
+
+      expect(searchInput.attr('tabindex')).toEqual('5');
+      expect($(el).attr('tabindex')).toEqual(undefined);
+    });
+
+    it('should pass tabindex to searchInput when tabindex is an expression', function() {
+      scope.tabValue = 22;
+      var el = createUiSelectMultiple({tabindex: '{{tabValue + 10}}'});
+      var searchInput = el.find('.ui-select-search');
+
+      expect(searchInput.attr('tabindex')).toEqual('32');
+      expect($(el).attr('tabindex')).toEqual(undefined);
+    });
+
+    it('should not give searchInput a tabindex when ui-select does not have one', function() {
+      var el = createUiSelectMultiple();
+      var searchInput = el.find('.ui-select-search');
+
+      expect(searchInput.attr('tabindex')).toEqual(undefined);
+      expect($(el).attr('tabindex')).toEqual(undefined);
     });
 
     it('should update size of search input after removing an item', function() {


### PR DESCRIPTION
This change adds the ability to specify tabindex on the ui-select
element and have it passed to the focusser input.  The tabindex is
removed from the ui-select div after it is applied to the focusser
input.
