### PR TITLE
Fix the bug where the input field gets full parent width when selected item is async

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -264,6 +264,7 @@
           var data = ctrl.parserResult.source($scope);
           var filteredItems = data.filter(function(i) {return selectedItems.indexOf(i) < 0;});
           setItemsFn(filteredItems);
+          ctrl.sizeSearchInput();
         });
       }
 


### PR DESCRIPTION
Adding a new item from the input field does resize the field correctly, but initially the width is parent's full width, making the input field go down to the next line as per the image below:

![simple_mail_admin___drupal_local](https://cloud.githubusercontent.com/assets/3193694/4233740/6d4169a0-39af-11e4-8025-8f63d76fa8ec.jpg)

The fix simply triggers the update of input field width upon change in the selected item (triggered due to async update of selected item).
