### PR TITLE
chore(bower): remove cruft from bower package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,10 @@
     "node_modules",
     "bower_components",
     "src",
-    "test"
+    "test",
+    "gulpfile.js",
+    "karma.conf.js",
+    "examples"
   ],
   "dependencies": {
     "angular": "~1.2"


### PR DESCRIPTION
bower package contains stuff people don't need:
- `gulpfile.js`
- `karma.conf.js`
- `examples/`
