### PR TITLE
Allow angular version 1.3+

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,11 +19,11 @@
     "examples"
   ],
   "dependencies": {
-    "angular": "~1.2.18"
+    "angular": ">=1.2.18"
   },
   "devDependencies": {
     "jquery": "~1.11",
-    "angular-sanitize": "~1.2.18",
-    "angular-mocks": "~1.2.18"
+    "angular-sanitize": ">=1.2.18",
+    "angular-mocks": ">=1.2.18"
   }
 }


### PR DESCRIPTION
Angular came out with version 1.3.0 and these bower version strings do not permit the minor version change.
