### PR TITLE
Focus stealing fix (Issue #283)

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -351,11 +351,9 @@
       if (!ctrl.open) return;        
       _resetSearchInput();
       ctrl.open = false;
-      if (!ctrl.multiple){
-        $timeout(function(){
-          ctrl.focusser.prop('disabled', false);
-          if (!skipFocusser) ctrl.focusser[0].focus();
-        },0,false);
+      if (!ctrl.multiple){        
+        ctrl.focusser.prop('disabled', false);
+        if (!skipFocusser) ctrl.focusser[0].focus();
       }
     };
 


### PR DESCRIPTION
Timeout is stealing focus back to the closed select, when click on other select.
Because of timeout = 0, I hope it doesn't brake other functionality.
