### PR TITLE
inline javascript may cause an error if the content policy restricts it

### DIFF
--- a/src/bootstrap/choices.tpl.html
+++ b/src/bootstrap/choices.tpl.html
@@ -5,7 +5,7 @@
     <div class="divider" ng-show="$select.isGrouped && $index > 0"></div>
     <div ng-show="$select.isGrouped" class="ui-select-choices-group-label dropdown-header" ng-bind-html="$group.name"></div>
     <div class="ui-select-choices-row" ng-class="{active: $select.isActive(this), disabled: $select.isDisabled(this)}">
-      <a href="javascript:void(0)" class="ui-select-choices-row-inner"></a>
+      <a href="" class="ui-select-choices-row-inner"></a>
     </div>
   </li>
 </ul>

--- a/src/select2/match-multiple.tpl.html
+++ b/src/select2/match-multiple.tpl.html
@@ -4,9 +4,9 @@
   do not work: [class^="select2-choice"]
 -->
 <span class="ui-select-match">
-  <li class="ui-select-match-item select2-search-choice" ng-repeat="$item in $select.selected" 
+  <li class="ui-select-match-item select2-search-choice" ng-repeat="$item in $select.selected"
       ng-class="{'select2-search-choice-focus':$select.activeMatchIndex === $index}">
       <span uis-transclude-append></span>
-      <a href="javascript:;" class="ui-select-match-close select2-search-choice-close" ng-click="$select.removeChoice($index)" tabindex="-1"></a>
+      <a href="" class="ui-select-match-close select2-search-choice-close" ng-click="$select.removeChoice($index)" tabindex="-1"></a>
   </li>
 </span>


### PR DESCRIPTION
so I think a blank href may be the best option.

In Chrome I got:

<blockquote>Refused to execute JavaScript URL because it violates the following Content Security Policy directive: "default-src 'self'". Either the 'unsafe-inline' keyword, a hash ('sha256-...'), or a nonce ('nonce-...') is required to enable inline execution. Note also that 'script-src' was not explicitly set, so 'default-src' is used as a fallback.
<blockquote>
