### PR TITLE
#258 Validates ng-required when multiple is used.

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -635,6 +635,15 @@
         $select.onSelectCallback = $parse(attrs.onSelect);
         $select.onRemoveCallback = $parse(attrs.onRemove);
 
+        // When configured for multiple, override $isEmpty so that ng-required works as expected.
+        if ($select.multiple) {
+          var defaultIsEmptyFn = ngModel.$isEmpty;
+
+          ngModel.$isEmpty = function(value) {
+            return (angular.isArray(value) && value.length === 0) || defaultIsEmptyFn(value);
+          };
+        }
+
         //From view --> model
         ngModel.$parsers.unshift(function (inputValue) {
           var locals = {},

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -1520,6 +1520,13 @@ describe('ui-select tests', function() {
          .toBe("Wladimir <wladimir@email.com>Samantha <samantha@email.com>Nicole <nicole@email.com>");
 
     });
+
+    it('should be marked invalid when required and empty', function() {
+      scope.selection.selectedMultiple = [];
+      var el = createUiSelectMultiple({required: true});
+      expect(el.scope().$select.ngModel.$invalid).toBe(true);
+      expect(el.scope().$select.ngModel.$error.required).toBe(true);
+    });
   });
 
   describe('default configuration via uiSelectConfig', function() {


### PR DESCRIPTION
This PR overrides `NgModelController.$isEmpty` when `multiple` is used so validation with `ng-required` works as expected.