### PR TITLE
Prevent selection of hidden search input on close

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -840,7 +840,7 @@
           }
 
           if (!contains && !$select.clickTriggeredSelect) {
-            $select.close();
+            $select.close(true);
             scope.$digest();
           }
           $select.clickTriggeredSelect = false;


### PR DESCRIPTION
Here is a case of issue:
1) click on uiSelect element with search enabled
Result: select options shown, search input is focused, user can enter any filter text
2) click on any another text input in document
Expected: another input is focused and user can enter text into it
Actual: another input is focused, but in a next moment it looses focus, user can't enter text to it

Unfortunately, I don't have enough experience to write karma test in reasonable amount of time.