### PR TITLE
Tagging - Trim the selected string item

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -385,7 +385,7 @@
                 // for `item` if it is a detected duplicate
                 if ( item === undefined ) return;
                 // create new item on the fly
-                item = ctrl.tagging.fct !== undefined ? ctrl.tagging.fct(ctrl.search) : item.replace(ctrl.taggingLabel,'');
+                item = ctrl.tagging.fct !== undefined ? ctrl.tagging.fct(ctrl.search) : item.replace(ctrl.taggingLabel,'').trim();
               }
             }
             // search ctrl.selected for dupes potentially caused by tagging and return early if found


### PR DESCRIPTION
When taggingLabel is used a space is inserted between search and the taggingLabel.
When the item is pushed to the selected array, only the taggingLabel is removed. Not the extra space
