### PR TITLE
supports Angular 1.3's $touched attribute on close

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -422,6 +422,7 @@
     // Closes the dropdown
     ctrl.close = function(skipFocusser) {
       if (!ctrl.open) return;
+      if (ctrl.ngModel && ctrl.ngModel.$setTouched) ctrl.ngModel.$setTouched();
       _resetSearchInput();
       ctrl.open = false;
       if (!ctrl.multiple){


### PR DESCRIPTION
If the ngModel is defined and an angular version with $touched is used, the select will mark the ngModel as touched when the list closes, to make it consistent with the native select control.