### PR TITLE
Fixed undesired submit action

### DIFF
--- a/src/bootstrap/match.tpl.html
+++ b/src/bootstrap/match.tpl.html
@@ -3,10 +3,10 @@
     <span ng-show="$select.isEmpty()" class="text-muted">{{$select.placeholder}}</span>
     <span ng-hide="$select.isEmpty()" ng-transclude=""></span>
   </button>
-  <button class="btn btn-default col-sm-2 col-md-1" ng-if="$select.allowClear && !$select.isEmpty()" ng-click="$select.select(undefined)">
+  <button type="button" class="btn btn-default col-sm-2 col-md-1" ng-if="$select.allowClear && !$select.isEmpty()" ng-click="$select.select(undefined)">
     <span class="glyphicon glyphicon-remove ui-select-toggle"></span>
   </button>
-  <button class="btn btn-default col-sm-2 col-md-1" ng-click="$select.activate()">
+  <button type="button" class="btn btn-default col-sm-2 col-md-1" ng-click="$select.activate()">
     <span class="caret ui-select-toggle" ng-click="$select.toggle($event)"></span>
   </button>
 </div>


### PR DESCRIPTION
If you use ui-select inside a form, the form gets submitted when you click the 'caret' button, by adding a type in the button it prevents this behavior :3.
tested in Chrome v.38.0.2125.122 using AngularJS v.1.2.27