### PR TITLE
Trim the trailing space left by a new tag's label.

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -410,7 +410,8 @@
                   item = ctrl.tagging.fct(ctrl.search);
                 // if item type is 'string', apply the tagging label
                 } else if ( typeof item === 'string' ) {
-                  item = item.replace(ctrl.taggingLabel,'');
+                  // trim the trailing space
+                  item = item.replace(ctrl.taggingLabel,'').trim();
                 }
               }
             }


### PR DESCRIPTION
Already done in #447, but got removed by https://github.com/angular-ui/ui-select/commit/41ba28ffb3f807c71634bc449f282e1b259a1c0a.
