### PR TITLE
Fix placeholder not being shown for select2

### DIFF
--- a/src/select2/select.tpl.html
+++ b/src/select2/select.tpl.html
@@ -1,7 +1,7 @@
 <div class="ui-select-container select2 select2-container"
      ng-class="{'select2-container-active select2-dropdown-open open': $select.open,
                 'select2-container-disabled': $select.disabled,
-                'select2-container-active': $select.focus, 
+                'select2-container-active': $select.focus,
                 'select2-allowclear': $select.allowClear && !$select.isEmpty()}">
   <div class="ui-select-match"></div>
   <div class="select2-drop select2-with-searchbox select2-drop-active"
@@ -9,6 +9,7 @@
     <div class="select2-search" ng-show="$select.searchEnabled">
       <input type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
              class="ui-select-search select2-input"
+             placeholder="{{$select.placeholder}}"
              ng-model="$select.search">
     </div>
     <div class="ui-select-choices"></div>

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -1054,6 +1054,11 @@ describe('ui-select tests', function() {
         expect($(el).find('.ui-select-search')).not.toHaveClass('ng-hide');
       });
 
+      it('should include the placeholder in the input when true', function() {
+        setupSelectComponent('true', 'selectize');
+        expect($(el).find('.ui-select-search').attr('placeholder')).toEqual('Pick one...');
+      });
+
       it('should hide search input when false', function() {
         setupSelectComponent(false, 'selectize');
         expect($(el).find('.ui-select-search')).toHaveClass('ng-hide');
@@ -1066,6 +1071,11 @@ describe('ui-select tests', function() {
       it('should show search input when true', function() {
         setupSelectComponent('true', 'select2');
         expect($(el).find('.select2-search')).not.toHaveClass('ng-hide');
+      });
+
+      it('should include the placeholder in the input when true', function() {
+        setupSelectComponent('true', 'select2');
+        expect($(el).find('.select2-search input').attr('placeholder')).toEqual('Pick one...');
       });
 
       it('should hide search input when false', function() {
@@ -1081,6 +1091,11 @@ describe('ui-select tests', function() {
         setupSelectComponent('true', 'bootstrap');
         clickMatch(el);
         expect($(el).find('.ui-select-search')).not.toHaveClass('ng-hide');
+      });
+
+      it('should include the placeholder in the input when true', function() {
+        setupSelectComponent('true', 'bootstrap');
+        expect($(el).find('.ui-select-search').attr('placeholder')).toEqual('Pick one...');
       });
 
       it('should hide search input when false', function() {


### PR DESCRIPTION
The placeholder is currently not being shown for the single-selection select2 theme. This pull request adds the missing placeholder attribute and tests that the placeholder is present on all themes.