### PR TITLE
Properly handle HTML5 data-* attributes

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -1177,6 +1177,7 @@
 
           var transcludedMatch = transcluded.querySelectorAll('.ui-select-match');
           transcludedMatch.removeAttr('ui-select-match'); //To avoid loop in case directive as attr
+          transcludedMatch.removeAttr('data-ui-select-match'); // Properly handle HTML5 data-attributes
           if (transcludedMatch.length !== 1) {
             throw uiSelectMinErr('transcluded', "Expected 1 .ui-select-match but got '{0}'.", transcludedMatch.length);
           }
@@ -1184,6 +1185,7 @@
 
           var transcludedChoices = transcluded.querySelectorAll('.ui-select-choices');
           transcludedChoices.removeAttr('ui-select-choices'); //To avoid loop in case directive as attr
+          transcludedChoices.removeAttr('data-ui-select-choices'); // Properly handle HTML5 data-attributes
           if (transcludedChoices.length !== 1) {
             throw uiSelectMinErr('transcluded', "Expected 1 .ui-select-choices but got '{0}'.", transcludedChoices.length);
           }


### PR DESCRIPTION
Hi,

I set up a small fix, so one could use data-* attributes for `ui-select-match` and `ui-select-choices`.
After this fix, something like this is possible:

```
<div data-ui-select data-ng-model="vm.selectedItem" data-theme="bootstrap" data-reset-search-input="false">
	<div data-ui-select-match data-placeholder="select sth...">
		{{ $select.selected }}
	</div>
	<div data-ui-select-choices data-repeat="item in vm.possibleItems| filter: $select.search">
		<span data-ng-bind-html="item | highlight: $select.search"></span>
	</div>
</div>
```

Without the fix this code causes Google Chrome to hang (some JS goes into the loop, probably the one described in the comment on line 1179 and 1186). With the fix it just works, and one can have a HTML5-validatable template.