### PR TITLE
Remove duplicate file comment in select.css

### DIFF
--- a/src/select.css
+++ b/src/select.css
@@ -1,11 +1,3 @@
-/*!
- * ui-select
- * http://github.com/angular-ui/ui-select
- * Version: 0.9.5 - 2014-12-12T16:07:20.859Z
- * License: MIT
- */
-
-
 /* Style when highlighting a search. */
 .ui-select-highlight {
   font-weight: bold;


### PR DESCRIPTION
Was introduced in 230216516ce5d929665e4089a45cab9ea3ed2f69

Since the comment is preserved my minifiers this wastes some bytes if the file is directly included.