### PR TITLE
Feature request / Bug Fix.  Pre-populating multi-select with selections not in source

### DIFF
--- a/examples/demo-multi-select.html
+++ b/examples/demo-multi-select.html
@@ -164,6 +164,20 @@
   <p>Selected: {{multipleDemo.selectedPeopleSimple}}</p>
 
   <hr>
+  <hr>
+  <h3>Array of objects tracked by name and with initial items not in source</h3>
+  <ui-select multiple ng-model="multipleDemo.selectedPeopleCustom" allow-custom-selected="true" theme="bootstrap" ng-disabled="disabled" close-on-select="false" style="width: 800px;" title="Choose a person">
+      <ui-select-match placeholder="Select person...">{{$item.name}} &lt;{{$item.email}}&gt;</ui-select-match>
+      <ui-select-choices repeat="person in people track by person.name">
+          <div ng-bind-html="person.name | highlight: $select.search"></div>
+          <small>
+              email: {{person.email}}
+              age: <span ng-bind-html="''+person.age | highlight: $select.search"></span>
+          </small>
+      </ui-select-choices>
+  </ui-select>
+  <p>Selected: {{multipleDemo.selectedPeopleCustom}}</p>
+  <hr>
   <h3>Array of objects (with groupBy)</h3>
   <ui-select multiple ng-model="multipleDemo.selectedPeopleWithGroupBy" theme="bootstrap" ng-disabled="disabled" close-on-select="false" style="width: 800px;" title="Choose a person">
     <ui-select-match placeholder="Select person...">{{$item.name}} &lt;{{$item.email}}&gt;</ui-select-match>

--- a/examples/demo.js
+++ b/examples/demo.js
@@ -140,6 +140,11 @@ app.controller('DemoCtrl', function($scope, $http, $timeout) {
   $scope.multipleDemo.selectedPeople2 = $scope.multipleDemo.selectedPeople;
   $scope.multipleDemo.selectedPeopleWithGroupBy = [$scope.people[8], $scope.people[6]];
   $scope.multipleDemo.selectedPeopleSimple = ['samantha@email.com','wladimir@email.com'];
+  $scope.multipleDemo.selectedPeopleCustom = [
+	  { name: 'Samantha',  email: 'something different than array source',  group: 'bar', age: 30 },
+	  { name: 'new person',  email: 'new@new.com',  group: 'bar', age: 30 },
+    { name: 'Adam',  email: 'new@new.com',  group: 'bar', age: 30 }
+  ];
 
 
   $scope.address = {};

--- a/src/select.js
+++ b/src/select.js
@@ -982,9 +982,9 @@
                 if (!checkFnMultiple($select.selected, inputValue[k])){
                   //add item to resultMultiple as before
                   var added = checkFnMultiple(data, inputValue[k]);
-                  //if item wasn't added to resultMultiple and there is a track by set
+                  //if there is data and item wasn't added to resultMultiple and there is a track by set
                   //and allowCustomSelected is set to true
-                  if(!added && matches && $select.allowCustomSelected) {
+                  if(data.length > 0 && !added && matches && $select.allowCustomSelected) {
                     //then check if the correct track by is defined
                     if(angular.isDefined(inputValue[k][matches[1]])) {
                       //check there isn't already an item in resultMultiple with that track by

--- a/src/select.js
+++ b/src/select.js
@@ -919,7 +919,7 @@
 
         $select.onSelectCallback = $parse(attrs.onSelect);
         $select.onRemoveCallback = $parse(attrs.onRemove);
-        $select.allowCustomOptions = angular.isDefined(attrs.allowCustomSelected) ? $parse(attrs.allowCustomSelected)() : uiSelectConfig.allowCustomSelected;
+        $select.allowCustomSelected = angular.isDefined(attrs.allowCustomSelected) ? $parse(attrs.allowCustomSelected)() : uiSelectConfig.allowCustomSelected;
 
         //From view --> model
         ngModel.$parsers.unshift(function (inputValue) {
@@ -983,8 +983,8 @@
                   //add item to resultMultiple as before
                   var added = checkFnMultiple(data, inputValue[k]);
                   //if item wasn't added to resultMultiple and there is a track by set
-                  //and allowCustomOptions is set to true
-                  if(!added && matches && $select.allowCustomOptions) {
+                  //and allowCustomSelected is set to true
+                  if(!added && matches && $select.allowCustomSelected) {
                     //then check if the correct track by is defined
                     if(angular.isDefined(inputValue[k][matches[1]])) {
                       //check there isn't already an item in resultMultiple with that track by


### PR DESCRIPTION
This change adds a flag called 'allow-custom-selected' to the ui-select directive which when set to true allows the form field to be pre-populated with selections that are not in the dropdown options source array as long as the selection object has the correct 'track by' parameter.

I can give a detailed use case if necessary.

I am also open to suggestions on what the flag should be called as I don't think 'allow-custom-selected' is very clear.

Finally I am happy to write the necessary tests but I tried to copy and adjust one of the existing tests (line 162 'should correctly render initial state with track by feature') but I don't think that test is working correctly as I could remove the track by portion of the ng-repeat and the test would still pass.  If you can give me some guidance on how to write a test for this feature that would be great.
