### PR TITLE
fix(focus): prevent focus stealing when clicking on other ui-select element

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -1191,7 +1191,8 @@
           }
 
           if (!contains && !$select.clickTriggeredSelect) {
-            $select.close(angular.element(e.target).closest('.ui-select-container.open').length > 0); // Skip focusser if the target is another select
+            var targetScope = angular.element(e.target).scope();
+            $select.close(targetScope && targetScope.$select && targetScope.$select !== $select); // Skip focusser if the target is another select
             scope.$digest();
           }
           $select.clickTriggeredSelect = false;

--- a/src/select.js
+++ b/src/select.js
@@ -1180,6 +1180,8 @@
         };
 
         function onDocumentClick(e) {
+          if (!$select.open) return; //Skip it if dropdown is close
+
           var contains = false;
 
           if (window.jQuery) {
@@ -1191,8 +1193,12 @@
           }
 
           if (!contains && !$select.clickTriggeredSelect) {
-            var targetScope = angular.element(e.target).scope();
-            $select.close(targetScope && targetScope.$select && targetScope.$select !== $select); // Skip focusser if the target is another select
+            //Will lose focus only with certain targets
+            var focusableControls = ['input','button','textarea'];
+            var targetScope = angular.element(e.target).scope(); //To check if target is other ui-select
+            var skipFocusser = targetScope && targetScope.$select && targetScope.$select !== $select; //To check if target is other ui-select
+            if (!skipFocusser) skipFocusser =  ~focusableControls.indexOf(e.target.tagName.toLowerCase()); //Check if target is input, button or textarea
+            $select.close(skipFocusser);
             scope.$digest();
           }
           $select.clickTriggeredSelect = false;


### PR DESCRIPTION
- [x] Fix focus stealing when ui-select is open and clicking on other ui-select

Not working [Plunker](http://plnkr.co/edit/o7JC4bFWIf0KpcnzxGIQ?p=preview)
Fixed [Plunker](http://plnkr.co/edit/mLIvTBnL8voBLekPayQE?p=preview)

- [x] Fix focus stealing when ui-select is open and clicking on other inputs (#646)

Not working [Plunker](http://plnkr.co/edit/MQ1VuldDLsm6GDNPMEXU?p=preview)
Fixed [Plunker](http://plnkr.co/edit/uvfqngiOclpE47fvXHvh?p=preview)


Fixes #283 , Fixes #253, Fixes #598, Fixes #646  
