### PR TITLE
If tagging mode is activate, do not check values

### DIFF
--- a/dist/select.js
+++ b/dist/select.js
@@ -1004,6 +1004,7 @@
                 return false;
               };
               if (!inputValue) return resultMultiple; //If ngModel was undefined
+              if ($select.tagging.isActivated) return inputValue;
               for (var k = inputValue.length - 1; k >= 0; k--) {
                 if (!checkFnMultiple($select.selected, inputValue[k])){
                   checkFnMultiple(data, inputValue[k]);


### PR DESCRIPTION
Motivation: Fix #540
The tagging mode is designed to allow new values to be added to the model.
It does not make sense to check those values against the list of choices when going from model --> view.