### PR TITLE
If tagging mode is activated, do not check values

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -1004,6 +1004,7 @@
                 return false;
               };
               if (!inputValue) return resultMultiple; //If ngModel was undefined
+              if ($select.tagging.isActivated) return inputValue;
               for (var k = inputValue.length - 1; k >= 0; k--) {
                 if (!checkFnMultiple($select.selected, inputValue[k])){
                   checkFnMultiple(data, inputValue[k]);

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -340,6 +340,14 @@ describe('ui-select tests', function() {
 
     expect($(el).scope().$select.selected).toEqual("I don't exist");
   });
+  
+  it('should keep the model intact when the tagging attribute is defined', function() {
+    scope.selection.selected.push("I am not on the list of choices");
+    var el = createUiSelect({tagging: true});
+    clickMatch(el);
+
+    expect($(el).scope().$select.selected).toEqual("I am not on the list of choices");
+  });
 
   it('should format new items using the tagging function when the attribute is a function', function() {
     scope.taggingFunc = function (name) {


### PR DESCRIPTION
Motivation: Fix #540
The tagging mode is designed to allow new values to be added to the model.
It does not make sense to check those values against the list of choices when going from model --> view.