### PR TITLE
Patch to allow for complex trackBy expressions

### DIFF
--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -86,7 +86,7 @@ uis.directive('uiSelect',
                     var parseByTrackBy = $parse($select.parserResult.trackByExp);
                     var resultObj = {}, valueObj = {};
                     resultObj[$select.parserResult.itemName] = result;
-                    valueObj[$select.parserResult.itemName];
+                    valueObj[$select.parserResult.itemName] = value;
 
                     if(parseByTrackBy(resultObj) == parseByTrackBy(valueObj)){
                         resultMultiple.unshift(list[p]);

--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -83,8 +83,12 @@ uis.directive('uiSelect',
                 locals[$select.parserResult.itemName] = list[p];
                 result = $select.parserResult.modelMapper(scope, locals);
                 if($select.parserResult.trackByExp){
-                    var matches = /\.(.+)/.exec($select.parserResult.trackByExp);
-                    if(matches.length>0 && result[matches[1]] == value[matches[1]]){
+                    var parseByTrackBy = $parse($select.parserResult.trackByExp);
+                    var resultObj = {}, valueObj = {};
+                    resultObj[$select.parserResult.itemName] = result;
+                    valueObj[$select.parserResult.itemName];
+
+                    if(parseByTrackBy(resultObj) == parseByTrackBy(valueObj)){
                         resultMultiple.unshift(list[p]);
                         return true;
                     }


### PR DESCRIPTION
This allows for complex trackBy expressions, such as `item.name + '/' + item.version`.  Previous versions would end up causing duplicates in the repeater directive, since the matches regex would end up as undefined.  This would effectively cause items to be tracked by only the first portion (in this case, `item.name`), resulting in duplicates.
