### PR TITLE
Fix issue with the sizing of the text input field

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -377,9 +377,12 @@ uis.controller('uiSelectCtrl',
       _searchInput.css('width',newWidth+'px');
     };
     $timeout(function(){ //Give tags time to render correctly
-      if (container.clientWidth === 0 && !containerSizeWatch){
-        containerSizeWatch = $scope.$watch(function(){ return container.clientWidth;}, function(newValue){
-          if (newValue !== 0){
+      if ((container.clientWidth === 0 || input.offsetParent === null) && !containerSizeWatch) {
+        containerSizeWatch = $scope.$watchGroup([
+          function(){ return container.clientWidth; },
+          function(){ return input.offsetParent; }
+        ], function(newValues){
+          if (newValues[0] !== 0 && newValues[1] !== null){
             calculate();
             containerSizeWatch();
             containerSizeWatch = null;

--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -212,6 +212,8 @@ uis.directive('uiSelect',
       attrs.$observe('disabled', function() {
         // No need to use $eval() (thanks to ng-disabled) since we already get a boolean instead of a string
         $select.disabled = attrs.disabled !== undefined ? attrs.disabled : false;
+        // As the search input field may now become visible, it may be necessary to recompute its size
+        $select.sizeSearchInput();
       });
 
       attrs.$observe('resetSearchInput', function() {


### PR DESCRIPTION
Fix issue with the sizing of the text input field when the visibility of the input control is dynamically toggled, for example via the `ng-disabled` attribute on the `<ui-select>` element.

The problem is caused by the width calculation getting an incorrect 0 `offsetLeft` value for the input, as the `offsetParent` of the input is still `null` when the controller tries to calculate the width. The fix resolves this by adding a watch for the `offsetParent`, and only performing the width calculation when both the `offsetParent` *and* the container width are available.

I've created a Plunk to demonstrate the issue:

  http://plnkr.co/79Ajy18oWP88EopEKAmn

And here's the same example, but with the patch applied:

  http://plnkr.co/KdsdBldLBwLRfojjWY24

I've reproduced the problem in Safari, Chrome, Firefox, and IE. The fix works in all of them.