### PR TITLE
Fix for sizing bug introduced by #718

### DIFF
--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -211,8 +211,10 @@ uis.directive('uiSelect',
       attrs.$observe('disabled', function() {
         // No need to use $eval() (thanks to ng-disabled) since we already get a boolean instead of a string
         $select.disabled = attrs.disabled !== undefined ? attrs.disabled : false;
-        // As the search input field may now become visible, it may be necessary to recompute its size
-        $select.sizeSearchInput();
+        if ($select.multiple) {
+          // As the search input field may now become visible, it may be necessary to recompute its size
+          $select.sizeSearchInput();
+        }
       });
 
       attrs.$observe('resetSearchInput', function() {


### PR DESCRIPTION
The search input size was being calculated incorrectly for non-multiple select instances using the Bootstrap theme. Remedy by only calling the sizing function when the select is in multi mode, which is how this function is guarded on other call sites as well.

Check out the Bootstrap select field on the `demo.html` page to see the problem in action.