### PR TITLE
Remove 'disabled' attribute from DOM if root element is not <select>

### DIFF
--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -153,6 +153,12 @@ uis.directive('uiSelect',
           });
         }
 
+        // <div>s and other non-form elements should not have 'disabled' attribute and it causes problems in IE
+        // so if current theme uses something other than <select>, remove 'disabled' attribute from root element in DOM
+        if (element.prop('tagName') != "select") {
+          element.removeAttr('disabled');
+        }
+
         function onDocumentClick(e) {
           if (!$select.open) return; //Skip it if dropdown is close
 

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -546,6 +546,28 @@ describe('ui-select tests', function() {
     expect(isDropdownOpened(el3)).toEqual(true);
   });
 
+  it('should not have disabled attribute on div', function() {
+    var el1 = createUiSelect({disabled: true, theme: 'bootstrap'});
+    expect(el1.attr('disabled')).toEqual(undefined);
+    var el2 = createUiSelect({disabled: true, theme: 'select2'});
+    expect(el2.attr('disabled')).toEqual(undefined);
+    var el3 = createUiSelect({disabled: true, theme: 'selectize'});
+    expect(el3.attr('disabled')).toEqual(undefined);
+  });
+
+  it('should allow to change disabled state but not to add disabled attribute', function() {
+    var el = createUiSelect({disabled: true, theme: 'select2'});
+    expect(el.attr('disabled')).toEqual(undefined);
+    el.scope().$select.disabled = false;
+    scope.$digest();
+    expect(el.scope().$select.disabled).toEqual(false);
+    expect(el.attr('disabled')).toEqual(undefined);
+    el.scope().$select.disabled = true;
+    scope.$digest();
+    expect(el.scope().$select.disabled).toEqual(true);
+    expect(el.attr('disabled')).toEqual(undefined);
+  });
+
   it('should allow decline tags when tagging function returns null', function() {
     scope.taggingFunc = function (name) {
       return null;


### PR DESCRIPTION
Fixes #726.
Not sure if it will not break anything. If there's no code that reads 'disabled' attribute directly from DOM to determine if select widget is disabled, everything should be right.