### PR TITLE
Fix input size calculation

### DIFF
--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -68,6 +68,7 @@ uis.directive('uiSelect',
             $select.sortable = sortable !== undefined ? sortable : uiSelectConfig.sortable;
         });
 
+        attrs.disabled = attrs.disabled || false;
         attrs.$observe('disabled', function() {
           // No need to use $eval() (thanks to ng-disabled) since we already get a boolean instead of a string
           $select.disabled = attrs.disabled !== undefined ? attrs.disabled : false;


### PR DESCRIPTION
Since AngularJS 1.3.1 or higher version changed the default behavior of
attrs.$observe(). If we dont't have a `ngDisabled` on uiSelect, the
initial calculation won't work in attrs.$observe('disabled')

Link: https://github.com/angular/angular.js/commit/531a8de72c439d8ddd064874bf364c00cedabb11