### PR TITLE
Wrap focus in timeout to prevent Error: $rootScope:inprog

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -304,7 +304,9 @@ uis.controller('uiSelectCtrl',
   ctrl.clear = function($event) {
     ctrl.select(undefined);
     $event.stopPropagation();
-    ctrl.focusser[0].focus();
+    $timeout(function() {
+      ctrl.focusser[0].focus();
+    }, 0, false);
   };
 
   // Toggle dropdown


### PR DESCRIPTION
Clearing selection can result in $rootScope:inprog error when focus() is called and an $apply is already in progress. 

Fixed as described in https://docs.angularjs.org/error/$rootScope/inprog