### PR TITLE
Don't tab if 'TAB' is specified as a taggingToken

### DIFF
--- a/src/uiSelectMultipleDirective.js
+++ b/src/uiSelectMultipleDirective.js
@@ -176,7 +176,9 @@ uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelec
           if(KEY.isHorizontalMovement(key)){
             processed = _handleMatchSelection(key);
           }
-          if (processed  && key != KEY.TAB) {
+          if (processed  && key != KEY.TAB ||
+            key === KEY.TAB && ctrl.taggingTokens.isActivated &&
+              ~ctrl.taggingTokens.tokens.indexOf(KEY.TAB) ) {
             //TODO Check si el tab selecciona aun correctamente
             //Crear test
             e.preventDefault();


### PR DESCRIPTION
Prevent default behavior of TAB key if TAB is a specified taggingToken. This may have to be enabled for multiple tagging select fields only.