### PR TITLE
fixed issue when an external change to the model doesn't propagate to th...

### DIFF
--- a/src/uiSelectMultipleDirective.js
+++ b/src/uiSelectMultipleDirective.js
@@ -135,6 +135,7 @@ uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelec
       //Watch for external model changes 
       scope.$watchCollection(function(){ return ngModel.$modelValue; }, function(newValue, oldValue) {
         if (oldValue != newValue){
+          $select.selected = ngModel.$modelValue;
           ngModel.$modelValue = null; //Force scope model value and ngModel value to be out of sync to re-run formatters
           $selectMultiple.refreshComponent();
         }


### PR DESCRIPTION
There was a problem where the a change to the model that uiSelectMultiple is bound to did not update the selected item array.  This resulted in an item not getting added back to the choices if it was removed from the model.