### PR TITLE
Stop propagation when pressing ENTER key from dropdown

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -437,6 +437,11 @@ uis.controller('uiSelectCtrl',
       _ensureHighlightVisible();
     }
 
+    if (key === KEY.ENTER) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+
   });
 
   // If tagging try to split by tokens and add items

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -1510,6 +1510,20 @@ describe('ui-select tests', function() {
 
     });
 
+    it('should stop the propagation when pressing ENTER key from dropdown', function() {
+
+        var el = createUiSelectMultiple();
+        var searchInput = el.find('.ui-select-search');
+        spyOn(jQuery.Event.prototype, 'preventDefault');
+        spyOn(jQuery.Event.prototype, 'stopPropagation');
+
+        triggerKeydown(searchInput, Key.Down)
+        triggerKeydown(searchInput, Key.Enter)
+        expect(jQuery.Event.prototype.preventDefault).toHaveBeenCalled();
+        expect(jQuery.Event.prototype.stopPropagation).toHaveBeenCalled();
+
+    });
+
     it('should increase $select.activeIndex when pressing DOWN key from dropdown', function() {
 
         var el = createUiSelectMultiple();


### PR DESCRIPTION
## What does this Pull Request Do?

Fix the event propagation when pressing enter key from dropdown

## How should this be manually tested?

Run the tests and try the demos

## What are the relevant issues?

https://github.com/angular-ui/ui-select/issues/862
