### PR TITLE
Fix width calculation to allow for different padding

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -344,7 +344,7 @@ uis.controller('uiSelectCtrl',
           if (containerWidth === 0) {
             return false;
           }
-          var inputWidth = containerWidth - input.offsetLeft - 10;
+          var inputWidth = containerWidth - input.offsetLeft - ctrl.searchInput.parent()[0].offsetLeft - 5;
           if (inputWidth < 50) inputWidth = containerWidth;
           ctrl.searchInput.css('width', inputWidth+'px');
           return true;


### PR DESCRIPTION
This PR uses the offsetLeft parameter to calculate the input size. It makes the assumption that offsetLeft (which is an available member) is the same as the right side, and then adds some margin.

This allows for different padding to be used, which is what the bootstrap themes do.