### PR TITLE
Fix styling for bootstrap placeholder

### DIFF
--- a/src/bootstrap/match.tpl.html
+++ b/src/bootstrap/match.tpl.html
@@ -1,11 +1,11 @@
 <div class="ui-select-match" ng-hide="$select.open" ng-disabled="$select.disabled" ng-class="{'btn-default-focus':$select.focus}">
   <span tabindex="-1"
-      class="btn btn-default form-control ui-select-toggle"
+      class="form-control ui-select-toggle"
       aria-label="{{ $select.baseTitle }} activate"
       ng-disabled="$select.disabled" 
       ng-click="$select.activate()"
       style="outline: 0;">
-    <span ng-show="$select.isEmpty()" class="ui-select-placeholder text-muted">{{$select.placeholder}}</span>
+    <span ng-show="$select.isEmpty()" class="ui-select-placeholder">{{$select.placeholder}}</span>
     <span ng-hide="$select.isEmpty()" class="ui-select-match-text pull-left" ng-class="{'ui-select-allow-clear': $select.allowClear && !$select.isEmpty()}" ng-transclude=""></span>
     <i class="caret pull-right" ng-click="$select.toggle($event)"></i>
     <a ng-show="$select.allowClear && !$select.isEmpty()" aria-label="{{ $select.baseTitle }} clear" style="margin-right: 10px" 

--- a/src/common.css
+++ b/src/common.css
@@ -171,6 +171,19 @@ body > .ui-select-bootstrap.open {
   border-right: 1px solid #428bca;
 }
 
+.ui-select-bootstrap .ui-select-placeholder {
+    color: #999;
+    opacity: 1;
+}
+
+.ui-select-bootstrap .ui-select-placeholder {
+    color: #999;
+}
+
+.ui-select-bootstrap .ui-select-placeholder {
+    color: #999;
+}
+
 .ui-select-bootstrap .ui-select-choices-row>a {
     display: block;
     padding: 3px 20px;


### PR DESCRIPTION
This builds upon the PR #816 which fixes the styling of bootstrap selects to correctly fit in a form. This PR removes the text-muted style from the placeholder, which while it might have the same color in the default bootstrap, is actually not compatible with the bootstrap less files, so when a bootstrap theme is used, the color is wrong. With the text-muted style, it's difficult to override this.
This PR adds styling to make the placeholder as per the default bootstrap theme, but it can be further styled with less if needed.