### PR TITLE
Fix: ignore metakeys when field has focus but dropdown is closed

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -32,7 +32,7 @@ var KEY = {
             return true;
         }
 
-        if (e.metaKey) return true;
+        if (e.metaKey || e.ctrlKey || e.altKey) return true;
 
         return false;
     },


### PR DESCRIPTION
This fix prevents ui-select from catching keystrokes when ctrl or alt is pressed. For example, when a field has focus, pressing ctrl-enter will no longer result in opening the dropdown. This way the webpage can use these shortcuts without ui-select stealing them away.