### PR TITLE
Remove confusing ng-disabled="disabled" in demos

### DIFF
--- a/examples/demo-append-to-body.html
+++ b/examples/demo-append-to-body.html
@@ -83,7 +83,6 @@
     <p>Selected: {{address.selected.formatted_address}}</p>
     <ui-select ng-model="address.selected"
                theme="bootstrap"
-               ng-disabled="disabled"
                reset-search-input="false"
                style="width: 300px;"
                title="Choose an address"
@@ -101,7 +100,7 @@
   <div class="select-box" ng-if="appendToBodyDemo.present">
     <h3>Select2 theme</h3>
     <p>Selected: {{person.selected}}</p>
-    <ui-select ng-model="person.selected" theme="select2" ng-disabled="disabled" style="min-width: 300px;" title="Choose a person" append-to-body="true">
+    <ui-select ng-model="person.selected" theme="select2" style="min-width: 300px;" title="Choose a person" append-to-body="true">
       <ui-select-match placeholder="Select a person in the list or search his name/age...">{{$select.selected.name}}</ui-select-match>
       <ui-select-choices repeat="person in people | propsFilter: {name: $select.search, age: $select.search}">
         <div ng-bind-html="person.name | highlight: $select.search"></div>
@@ -117,7 +116,7 @@
   <div class="select-box" ng-if="appendToBodyDemo.present">
     <h3>Selectize theme</h3>
     <p>Selected: {{country.selected}}</p>
-    <ui-select ng-model="country.selected" theme="selectize" ng-disabled="disabled" style="width: 300px;" title="Choose a country" append-to-body="true">
+    <ui-select ng-model="country.selected" theme="selectize" style="width: 300px;" title="Choose a country" append-to-body="true">
       <ui-select-match placeholder="Select or search a country in the list...">{{$select.selected.name}}</ui-select-match>
       <ui-select-choices repeat="country in countries | filter: $select.search">
         <span ng-bind-html="country.name | highlight: $select.search"></span>

--- a/examples/demo-bind-to-single-property-async.html
+++ b/examples/demo-bind-to-single-property-async.html
@@ -65,7 +65,7 @@
   <h3>Select2 theme</h3>
   <h4>Single property binding with async data</h4>
   <p>Selected: {{personAsync.selected}}</p>
-  <ui-select ng-model="personAsync.selected" theme="select2" ng-disabled="disabled" style="min-width: 300px;" title="Single property binding with async data">
+  <ui-select ng-model="personAsync.selected" theme="select2" style="min-width: 300px;" title="Single property binding with async data">
     <ui-select-match placeholder="Select a person in the list or search his name/age...">{{$select.selected.name || $select.selected}}</ui-select-match>
     <ui-select-choices repeat="person.email as person in peopleAsync | propsFilter: {name: $select.search, age: $select.search}">
       <div ng-bind-html="person.name | highlight: $select.search"></div>

--- a/examples/demo-bind-to-single-property.html
+++ b/examples/demo-bind-to-single-property.html
@@ -64,7 +64,7 @@
 
   <h3>Select2 theme</h3>
   <p>Selected: {{person.selected}}</p>
-  <ui-select ng-model="person.selected" theme="select2" ng-disabled="disabled" style="min-width: 300px;" title="Choose a person">
+  <ui-select ng-model="person.selected" theme="select2" style="min-width: 300px;" title="Choose a person">
     <ui-select-match placeholder="Select a person in the list or search his name/age...">{{$select.selected.name}}</ui-select-match>
     <ui-select-choices repeat="person.email as person in people | propsFilter: {name: $select.search, age: $select.search}">
       <div ng-bind-html="person.name | highlight: $select.search"></div>

--- a/examples/demo-disable-search.html
+++ b/examples/demo-disable-search.html
@@ -65,7 +65,7 @@
 
   <h3>Bootstrap theme</h3>
   <p>Selected: {{person.selected}}</p>
-  <ui-select ng-model="person.selected" theme="bootstrap" search-enabled="searchEnabled" ng-disabled="disabled" style="min-width: 300px;" title="Choose a person">
+  <ui-select ng-model="person.selected" theme="bootstrap" search-enabled="searchEnabled" style="min-width: 300px;" title="Choose a person">
     <ui-select-match placeholder="Select a person in the list or search his name/age...">{{$select.selected.name}}</ui-select-match>
     <ui-select-choices repeat="person in people | propsFilter: {name: $select.search, age: $select.search}">
       <div ng-bind-html="person.name | highlight: $select.search"></div>
@@ -78,7 +78,7 @@
 
   <h3>Select2 theme</h3>
   <p>Selected: {{person.selected}}</p>
-  <ui-select ng-model="person.selected" theme="select2" search-enabled="searchEnabled" ng-disabled="disabled" style="min-width: 300px;">
+  <ui-select ng-model="person.selected" theme="select2" search-enabled="searchEnabled" style="min-width: 300px;">
     <ui-select-match placeholder="Select a person in the list or search his name/age...">{{$select.selected.name}}</ui-select-match>
     <ui-select-choices repeat="person in people | propsFilter: {name: $select.search, age: $select.search}">
       <div ng-bind-html="person.name | highlight: $select.search"></div>
@@ -91,7 +91,7 @@
 
   <h3>Selectize theme</h3>
   <p>Selected: {{country.selected}}</p>
-  <ui-select ng-model="country.selected" theme="selectize" search-enabled="searchEnabled" ng-disabled="disabled" style="width: 300px;">
+  <ui-select ng-model="country.selected" theme="selectize" search-enabled="searchEnabled" style="width: 300px;">
     <ui-select-match placeholder="Select or search a country in the list...">{{$select.selected.name}}</ui-select-match>
     <ui-select-choices repeat="country in countries | filter: $select.search">
       <span ng-bind-html="country.name | highlight: $select.search"></span>

--- a/examples/demo-event-on-select.html
+++ b/examples/demo-event-on-select.html
@@ -64,7 +64,7 @@
 
   <h3>Select2 theme</h3>
   <p>Selected: {{person.selected}}</p>
-  <ui-select ng-model="person.selected" theme="select2" on-select="someFunction($item, $model)" ng-disabled="disabled" style="min-width: 300px;" title="Choose a person">
+  <ui-select ng-model="person.selected" theme="select2" on-select="someFunction($item, $model)" style="min-width: 300px;" title="Choose a person">
     <ui-select-match placeholder="Select a person in the list or search his name/age...">{{$select.selected.name}}</ui-select-match>
     <ui-select-choices repeat="person.email as person in people | propsFilter: {name: $select.search, age: $select.search}">
       <div ng-bind-html="person.name | highlight: $select.search"></div>

--- a/examples/demo-focus.html
+++ b/examples/demo-focus.html
@@ -61,7 +61,7 @@
   <hr>
 
   <p>Regular uiSelect</p>
-  <ui-select ng-model="person.selected" theme="select2" ng-disabled="disabled" style="min-width: 300px;" title="Choose a person">
+  <ui-select ng-model="person.selected" theme="select2" style="min-width: 300px;" title="Choose a person">
     <ui-select-match placeholder="Select a person in the list or search his name/age...">{{$select.selected.name}}</ui-select-match>
     <ui-select-choices repeat="person in people | propsFilter: {name: $select.search, age: $select.search}">
       <div ng-bind-html="person.name | highlight: $select.search"></div>
@@ -77,7 +77,7 @@
   <br>
 
   <p>Using <b>uisAutofocus</b> to automatically get focus when loaded</p>
-  <ui-select autofocus ng-model="person.selected" theme="select2" ng-disabled="disabled" style="min-width: 300px;" title="Choose a person">
+  <ui-select autofocus ng-model="person.selected" theme="select2" style="min-width: 300px;" title="Choose a person">
     <ui-select-match placeholder="Select a person in the list or search his name/age...">{{$select.selected.name}}</ui-select-match>
     <ui-select-choices repeat="person in people | propsFilter: {name: $select.search, age: $select.search}">
       <div ng-bind-html="person.name | highlight: $select.search"></div>
@@ -93,7 +93,7 @@
   <br>
 
   <p>Using <b>uisFocusOn</b> defining a scope event name to listen</p>
-  <ui-select focus-on='UiSelectDemo1' ng-model="person.selected" theme="select2" ng-disabled="disabled" style="min-width: 300px;" title="Choose a person">
+  <ui-select focus-on='UiSelectDemo1' ng-model="person.selected" theme="select2" style="min-width: 300px;" title="Choose a person">
     <ui-select-match placeholder="Select a person in the list or search his name/age...">{{$select.selected.name}}</ui-select-match>
     <ui-select-choices repeat="person in people | propsFilter: {name: $select.search, age: $select.search}">
       <div ng-bind-html="person.name | highlight: $select.search"></div>

--- a/examples/demo-groupby.html
+++ b/examples/demo-groupby.html
@@ -66,7 +66,7 @@
   <p>Selected: {{person.selected}}</p>
 
   <h2>Grouped using a string (group-by="'country'")</h2>
-  <ui-select ng-model="person.selected" theme="select2" ng-disabled="disabled" style="min-width: 300px;" title="Choose a person">
+  <ui-select ng-model="person.selected" theme="select2" style="min-width: 300px;" title="Choose a person">
     <ui-select-match placeholder="Select a person in the list or search his name/age...">{{$select.selected.name}}</ui-select-match>
     <ui-select-choices group-by="'country'" repeat="person in people | propsFilter: {name: $select.search, age: $select.search}">
       <div ng-bind-html="person.name | highlight: $select.search"></div>
@@ -78,7 +78,7 @@
     </ui-select>
 
   <h2>Grouped using a function (group-by="someGroupFn")</h2>
-  <ui-select ng-model="person.selected" theme="select2" ng-disabled="disabled" style="min-width: 300px;" title="Choose a person">
+  <ui-select ng-model="person.selected" theme="select2" style="min-width: 300px;" title="Choose a person">
     <ui-select-match placeholder="Select a person in the list or search his name/age...">{{$select.selected.name}}</ui-select-match>
     <ui-select-choices group-by="someGroupFn" repeat="person in people | propsFilter: {name: $select.search, age: $select.search}">
       <div ng-bind-html="person.name | highlight: $select.search"></div>
@@ -90,7 +90,7 @@
     </ui-select>
 
   <h2>Simple (no groupBy)</h2>
-  <ui-select ng-model="person.selected" theme="select2" ng-disabled="disabled" style="min-width: 300px;" title="Choose a person">
+  <ui-select ng-model="person.selected" theme="select2" style="min-width: 300px;" title="Choose a person">
     <ui-select-match placeholder="Select a person in the list or search his name/age...">{{$select.selected.name}}</ui-select-match>
     <ui-select-choices repeat="person in people | propsFilter: {name: $select.search, age: $select.search}">
       <div ng-bind-html="person.name | highlight: $select.search"></div>

--- a/examples/demo-multi-select.html
+++ b/examples/demo-multi-select.html
@@ -65,7 +65,6 @@
  <!--  <h1>Bootstrap theme</h1>
   <ui-select ng-model="address.selected"
              theme="bootstrap"
-             ng-disabled="disabled"
              reset-search-input="false"
              style="width: 300px;">
     <ui-select-match placeholder="Enter an address...">{{$select.selected.formatted_address}}</ui-select-match>
@@ -78,7 +77,7 @@
   <p>Selected: {{address.selected.formatted_address}}</p>
 
   <h3>Multi select</h3>
-  <ui-select multiple ng-model="friends" theme="bootstrap" ng-disabled="disabled" style="width: 300px;">
+  <ui-select multiple ng-model="friends" theme="bootstrap" style="width: 300px;">
     <ui-select-match placeholder="Search and select friends...">{{$item.name}}</ui-select-match>
     <ui-select-choices repeat="person in people | propsFilter: {name: $select.search, age: $select.search}">
       <div ng-bind-html="person.name | highlight: $select.search"></div>
@@ -89,7 +88,7 @@
   </ui-select>
   <p>Selected: {{friends|json}}</p>
  -->
-<!--   <ui-select ng-model="person.selected" theme="select2" ng-disabled="disabled" style="min-width: 300px;">
+<!--   <ui-select ng-model="person.selected" theme="select2" style="min-width: 300px;">
     <ui-select-match placeholder="Select a person in the list or search his name/age...">{{$select.selected.name}}</ui-select-match>
     <ui-select-choices repeat="person in people | propsFilter: {name: $select.search, age: $select.search}">
       <div ng-bind-html="person.name | highlight: $select.search"></div>
@@ -101,7 +100,7 @@
   </ui-select>
   <p>Selected: {{person.selected}}</p> -->
 <!--   <h1>Selectize theme</h1>
-  <ui-select ng-model="country.selected" theme="selectize" ng-disabled="disabled" style="width: 300px;">
+  <ui-select ng-model="country.selected" theme="selectize" style="width: 300px;">
     <ui-select-match placeholder="Select or search a country in the list...">{{$select.selected.name}}</ui-select-match>
     <ui-select-choices repeat="country in countries | filter: $select.search">
       <span ng-bind-html="country.name | highlight: $select.search"></span>
@@ -113,7 +112,7 @@
   <h1>Multi Selection Demos</h1>
 
   <h3>Array of strings</h3>
-  <ui-select multiple ng-model="multipleDemo.colors" theme="bootstrap" ng-disabled="disabled" close-on-select="false" style="width: 300px;" title="Choose a color">
+  <ui-select multiple ng-model="multipleDemo.colors" theme="bootstrap" close-on-select="false" style="width: 300px;" title="Choose a color">
     <ui-select-match placeholder="Select colors...">{{$item}}</ui-select-match>
     <ui-select-choices repeat="color in availableColors | filter:$select.search">
       {{color}}
@@ -122,7 +121,7 @@
   <p>Selected: {{multipleDemo.colors}}</p>
   <hr>
   <h3>Array of objects (sorting enabled)</h3>
-  <ui-select multiple ng-model="multipleDemo.selectedPeople" theme="bootstrap" ng-disabled="disabled" sortable="true" close-on-select="false" style="width: 800px;">
+  <ui-select multiple ng-model="multipleDemo.selectedPeople" theme="bootstrap" sortable="true" close-on-select="false" style="width: 800px;">
     <ui-select-match placeholder="Select person...">{{$item.name}} &lt;{{$item.email}}&gt;</ui-select-match>
     <ui-select-choices repeat="person in people | propsFilter: {name: $select.search, age: $select.search}">
       <div ng-bind-html="person.name | highlight: $select.search"></div>
@@ -136,7 +135,7 @@
 
   <hr>
   <h3>Deselect callback with single property binding</h3>
-  <ui-select multiple ng-model="multipleDemo.deSelectedPeople" on-remove="removed($item, $model)" theme="bootstrap" ng-disabled="disabled" close-on-select="false" style="width: 800px;" title="Choose a person">
+  <ui-select multiple ng-model="multipleDemo.deSelectedPeople" on-remove="removed($item, $model)" theme="bootstrap" close-on-select="false" style="width: 800px;" title="Choose a person">
     <ui-select-match placeholder="Select person...">{{$item.name}} &lt;{{$item.email}}&gt;</ui-select-match>
     <ui-select-choices repeat="person.email as person in people | propsFilter: {name: $select.search, age: $select.search}">
       <div ng-bind-html="person.name | highlight: $select.search"></div>
@@ -151,7 +150,7 @@
 
   <hr>
   <h3>Array of objects with single property binding</h3>
-  <ui-select multiple ng-model="multipleDemo.selectedPeopleSimple" theme="bootstrap" ng-disabled="disabled" close-on-select="false" style="width: 800px;" title="Choose a person">
+  <ui-select multiple ng-model="multipleDemo.selectedPeopleSimple" theme="bootstrap" close-on-select="false" style="width: 800px;" title="Choose a person">
     <ui-select-match placeholder="Select person...">{{$item.name}} &lt;{{$item.email}}&gt;</ui-select-match>
     <ui-select-choices repeat="person.email as person in people | propsFilter: {name: $select.search, age: $select.search}">
       <div ng-bind-html="person.name | highlight: $select.search"></div>
@@ -165,7 +164,7 @@
 
   <hr>
   <h3>Array of objects (with groupBy)</h3>
-  <ui-select multiple ng-model="multipleDemo.selectedPeopleWithGroupBy" theme="bootstrap" ng-disabled="disabled" close-on-select="false" style="width: 800px;" title="Choose a person">
+  <ui-select multiple ng-model="multipleDemo.selectedPeopleWithGroupBy" theme="bootstrap" close-on-select="false" style="width: 800px;" title="Choose a person">
     <ui-select-match placeholder="Select person...">{{$item.name}} &lt;{{$item.email}}&gt;</ui-select-match>
     <ui-select-choices group-by="someGroupFn" repeat="person in people | propsFilter: {name: $select.search, age: $select.search}">
       <div ng-bind-html="person.name | highlight: $select.search"></div>

--- a/examples/demo-tagging.html
+++ b/examples/demo-tagging.html
@@ -66,7 +66,7 @@
 
   <h3>Simple String Tags</h3>
   <h4>(With Custom Tag Label / Sort Enabled)</h4>
-  <ui-select multiple tagging tagging-label="(custom 'new' label)" ng-model="multipleDemo.colors" theme="bootstrap" sortable="true" ng-disabled="disabled" style="width: 300px;" title="Choose a color">
+  <ui-select multiple tagging tagging-label="(custom 'new' label)" ng-model="multipleDemo.colors" theme="bootstrap" sortable="true" style="width: 300px;" title="Choose a color">
     <ui-select-match placeholder="Select colors...">{{$item}}</ui-select-match>
     <ui-select-choices repeat="color in availableColors | filter:$select.search">
       {{color}}
@@ -77,7 +77,7 @@
 
   <h3>Simple String Tags </h3>
   <h4>(Predictive Search Model / No Labels)</h4>
-  <ui-select multiple tagging tagging-label="false" ng-model="multipleDemo.colors2" theme="bootstrap" ng-disabled="disabled" style="width: 300px;" title="Choose a color">
+  <ui-select multiple tagging tagging-label="false" ng-model="multipleDemo.colors2" theme="bootstrap" style="width: 300px;" title="Choose a color">
     <ui-select-match placeholder="Select colors...">{{$item}}</ui-select-match>
     <ui-select-choices repeat="color in availableColors | filter:$select.search">
       {{color}}
@@ -87,7 +87,7 @@
   <hr>
 
   <h3>Object Tags</h3>
-  <ui-select multiple tagging="tagTransform" ng-model="multipleDemo.selectedPeople" theme="bootstrap" ng-disabled="disabled" style="width: 800px;" title="Choose a person">
+  <ui-select multiple tagging="tagTransform" ng-model="multipleDemo.selectedPeople" theme="bootstrap" style="width: 800px;" title="Choose a person">
     <ui-select-match placeholder="Select person...">{{$item.name}} &lt;{{$item.email}}&gt;</ui-select-match>
     <ui-select-choices repeat="person in people | propsFilter: {name: $select.search, age: $select.search}">
       <div ng-if="person.isTag" ng-bind-html="person.name +' <small>(new)</small>'| highlight: $select.search"></div>
@@ -103,7 +103,7 @@
 
   <h3>Object Tags with Tokenization (Space, Forward Slash, Comma)</h3>
   <strong>Note that the SPACE character can't be used literally, use the keyword SPACE</strong>
-  <ui-select multiple tagging="tagTransform" tagging-tokens="SPACE|,|/" ng-model="multipleDemo.selectedPeople2" theme="bootstrap" ng-disabled="disabled" style="width: 800px;" title="Choose a person">
+  <ui-select multiple tagging="tagTransform" tagging-tokens="SPACE|,|/" ng-model="multipleDemo.selectedPeople2" theme="bootstrap" style="width: 800px;" title="Choose a person">
     <ui-select-match placeholder="Select person...">{{$item.name}} &lt;{{$item.email}}&gt;</ui-select-match>
     <ui-select-choices repeat="person in people | propsFilter: {name: $select.search, age: $select.search}">
       <div ng-if="person.isTag" ng-bind-html="person.name + ' ' + $select.taggingLabel | highlight: $select.search"></div>
@@ -117,7 +117,7 @@
   <p>Selected: {{multipleDemo.selectedPeople2}}</p>
 
   <h3>Tagging without multiple</h3>
-  <ui-select tagging="tagTransform" ng-model="person.selected" theme="bootstrap" ng-disabled="disabled" style="width: 800px;" title="Choose a person">
+  <ui-select tagging="tagTransform" ng-model="person.selected" theme="bootstrap" style="width: 800px;" title="Choose a person">
   <ui-select-match placeholder="Select person...">{{$select.selected.name}} &lt;{{$select.selected.email}}&gt;</ui-select-match>
   <ui-select-choices repeat="person in people | propsFilter: {name: $select.search, age: $select.search}">
     <div ng-if="person.isTag" ng-bind-html="person.name +' <small>(new)</small>'| highlight: $select.search"></div>

--- a/examples/demo.html
+++ b/examples/demo.html
@@ -66,7 +66,6 @@
   <p>Selected: {{address.selected.formatted_address}}</p>
   <ui-select ng-model="address.selected"
              theme="bootstrap"
-             ng-disabled="disabled"
              reset-search-input="false"
              style="width: 300px;"
              title="Choose an address">
@@ -80,7 +79,7 @@
 
   <h3>Select2 theme</h3>
   <p>Selected: {{person.selected}}</p>
-  <ui-select ng-model="person.selected" theme="select2" ng-disabled="disabled" style="min-width: 300px;" title="Choose a person">
+  <ui-select ng-model="person.selected" theme="select2" style="min-width: 300px;" title="Choose a person">
     <ui-select-match placeholder="Select a person in the list or search his name/age...">{{$select.selected.name}}</ui-select-match>
     <ui-select-choices repeat="person in people | propsFilter: {name: $select.search, age: $select.search}">
       <div ng-bind-html="person.name | highlight: $select.search"></div>
@@ -93,7 +92,7 @@
 
   <h3>Selectize theme</h3>
   <p>Selected: {{country.selected}}</p>
-  <ui-select ng-model="country.selected" theme="selectize" ng-disabled="disabled" style="width: 300px;" title="Choose a country">
+  <ui-select ng-model="country.selected" theme="selectize" style="width: 300px;" title="Choose a country">
     <ui-select-match placeholder="Select or search a country in the list...">{{$select.selected.name}}</ui-select-match>
     <ui-select-choices repeat="country in countries | filter: $select.search">
       <span ng-bind-html="country.name | highlight: $select.search"></span>


### PR DESCRIPTION
For some reason, a lot of the code in the demos contains the following attrubute:

```
<ui-select ng-disabled="disabled" …>
```

`ng-disabled="disabled"` doesn't have any effect, as it expects a `boolean`. This makes the demos confusing.