### PR TITLE
fix for #875, properly working tab in firefox

### DIFF
--- a/src/select2/choices.tpl.html
+++ b/src/select2/choices.tpl.html
@@ -1,4 +1,4 @@
-<ul class="ui-select-choices ui-select-choices-content select2-results">
+<ul tabindex="-1" class="ui-select-choices ui-select-choices-content select2-results">
   <li class="ui-select-choices-group" ng-class="{'select2-result-with-children': $select.choiceGrouped($group) }">
     <div ng-show="$select.choiceGrouped($group)" class="ui-select-choices-group-label select2-result-label" ng-bind="$group.name"></div>
     <ul role="listbox"


### PR DESCRIPTION
This fixes #875. Tab in firefox was not working properly because in some cases the <ul> tag in the select2 theme gets the focus. Explicitly putting tabindex="-1" on the tag fixes the bug. 
I do not understand how it is possible that <ul> gets the focus anyhow, thus with this fix I might have missed the underlying cause.