### PR TITLE
Prevent whole page scroll when scrolling ui-choices

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -96,7 +96,8 @@ var uis = angular.module('ui.select', [])
   generateId: function() {
     return latestId++;
   },
-  appendToBody: false
+  appendToBody: false,
+  preventPageScroll: true
 })
 
 // See Rename minErr and make it accessible from outside https://github.com/angular/angular.js/issues/6913

--- a/src/uiSelectChoicesDirective.js
+++ b/src/uiSelectChoicesDirective.js
@@ -47,6 +47,18 @@ uis.directive('uiSelectChoices',
         if (rowsInner.length !== 1) throw uiSelectMinErr('rows', "Expected 1 .ui-select-choices-row-inner but got '{0}'.", rowsInner.length);
         rowsInner.attr('uis-transclude-append', ''); //Adding uisTranscludeAppend directive to row element after choices element has ngRepeat
 
+        if ($select.preventPageScroll) {// Prevent the whole page for scrolling when the choices ul reaches it's scroll limits.
+          element.bind('mousewheel', function(event) {
+            var heightDif = this.offsetHeight - this.clientHeight,
+                maxScrollTop = this.scrollHeight - this.offsetHeight + heightDif;
+
+            if ((this.scrollTop === maxScrollTop && event.deltaY > 0) ||
+                (this.scrollTop === 0 && event.deltaY < 0)) {
+              event.preventDefault();
+            }
+          });
+        }
+
         $compile(element, transcludeFn)(scope); //Passing current transcludeFn to be able to append elements correctly from uisTranscludeAppend
 
         scope.$watch('$select.search', function(newValue) {

--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -39,6 +39,8 @@ uis.controller('uiSelectCtrl',
   ctrl.clickTriggeredSelect = false;
   ctrl.$filter = $filter;
 
+  ctrl.preventPageScroll = undefined; //Initialized inside uiSelect directive link function
+
   ctrl.searchInput = $element.querySelectorAll('input.ui-select-search');
   if (ctrl.searchInput.length !== 1) {
     throw uiSelectMinErr('searchInput', "Expected 1 input.ui-select-search but got '{0}'.", ctrl.searchInput.length);

--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -41,6 +41,14 @@ uis.directive('uiSelect',
           }
         }();
 
+        $select.preventPageScroll = function() {
+          if (angular.isDefined(attrs.preventPageScroll)) {
+            return $parse(attrs.preventPageScroll)();
+          } else {
+            return uiSelectConfig.preventPageScroll;
+          }
+        }();
+
         $select.onSelectCallback = $parse(attrs.onSelect);
         $select.onRemoveCallback = $parse(attrs.onRemove);
         


### PR DESCRIPTION
Prevent the browser's annoying default behavior of scroll the whole page
when scrolling in ui-choices options, useful when it has many
options, changeable in uiSelectConfig globals and preventPageScroll attribute.