### PR TITLE
Use npm to install required dependencies to run the tests.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,10 +9,10 @@ module.exports = function(config) {
 
     // List of files / patterns to load in the browser
     files: [
-      'bower_components/jquery/dist/jquery.js',
-      'bower_components/angular/angular.js',
-      'bower_components/angular-sanitize/angular-sanitize.js',
-      'bower_components/angular-mocks/angular-mocks.js',
+      'node_modules/jquery/dist/jquery.js',
+      'node_modules/angular/angular.js',
+      'node_modules/angular-sanitize/angular-sanitize.js',
+      'node_modules/angular-mocks/angular-mocks.js',
 
       'dist/select.js',
       'test/helpers.js',

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   },
   "version": "0.11.2",
   "devDependencies": {
+    "angular": "^1.2.18",
+    "angular-mocks": "^1.2.18",
+    "angular-sanitize": "^1.2.18",
     "bower": "~1.3",
     "del": "~0.1.1",
     "event-stream": "~3.1.0",
@@ -23,6 +26,7 @@
     "gulp-rename": "~0.2.2",
     "gulp-uglify": "~0.3.1",
     "gulp-util": "^2.2.19",
+    "jquery": "~1.11",
     "jshint-stylish": "~0.3.0",
     "karma": "^0.12.16",
     "karma-chrome-launcher": "^0.1.3",
@@ -33,7 +37,6 @@
     "karma-coverage": "~0.2"
   },
   "scripts": {
-    "postinstall": "bower install",
     "test": "gulp test"
   },
   "license": "MIT"


### PR DESCRIPTION
Angular, Angular Sanitize, Angular Mocks and JQuery.
Removed: post-install bower script. No longer need to call bower from npm.
This will help when you guys decide to publish the package in NPM.

