### PR TITLE
Do not run bower after install automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "karma-coverage": "~0.2"
   },
   "scripts": {
-    "postinstall": "bower install",
     "test": "gulp test"
   },
   "license": "MIT"


### PR DESCRIPTION
This should be an user action, not something automatically run on install.
We're using ui-select in a browserify project, and we don't need/have bower installed. Furthermore it pollutes the development folder with an unused bower_components.