### PR TITLE
Update search inputs type

### DIFF
--- a/src/bootstrap/select-multiple.tpl.html
+++ b/src/bootstrap/select-multiple.tpl.html
@@ -1,11 +1,11 @@
 <div class="ui-select-container ui-select-multiple ui-select-bootstrap dropdown form-control" ng-class="{open: $select.open}">
   <div>
     <div class="ui-select-match"></div>
-    <input type="text"
-           autocomplete="false" 
-           autocorrect="off" 
-           autocapitalize="off" 
-           spellcheck="false" 
+    <input type="search"
+           autocomplete="off"
+           autocorrect="off"
+           autocapitalize="off"
+           spellcheck="false"
            class="ui-select-search input-xs"
            placeholder="{{$selectMultiple.getPlaceholder()}}"
            ng-disabled="$select.disabled"

--- a/src/bootstrap/select.tpl.html
+++ b/src/bootstrap/select.tpl.html
@@ -1,6 +1,6 @@
 <div class="ui-select-container ui-select-bootstrap dropdown" ng-class="{open: $select.open}">
   <div class="ui-select-match"></div>
-  <input type="text" autocomplete="false" tabindex="-1"
+  <input type="search" autocomplete="off" tabindex="-1"
          aria-expanded="true"
          aria-label="{{ $select.baseTitle }}"
          aria-owns="ui-select-choices-{{ $select.generatedId }}"

--- a/src/select2/select-multiple.tpl.html
+++ b/src/select2/select-multiple.tpl.html
@@ -5,8 +5,8 @@
     <span class="ui-select-match"></span>
     <li class="select2-search-field">
       <input
-        type="text"
-        autocomplete="false"
+        type="search"
+        autocomplete="off"
         autocorrect="off"
         autocapitalize="off"
         spellcheck="false"

--- a/src/select2/select.tpl.html
+++ b/src/select2/select.tpl.html
@@ -7,7 +7,7 @@
   <div class="ui-select-dropdown select2-drop select2-with-searchbox select2-drop-active"
        ng-class="{'select2-display-none': !$select.open}">
     <div class="select2-search" ng-show="$select.searchEnabled">
-      <input type="text" autocomplete="false" autocorrect="false" autocapitalize="off" spellcheck="false"
+      <input type="search" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
        role="combobox"
        aria-expanded="true"
        aria-owns="ui-select-choices-{{ $select.generatedId }}"

--- a/src/selectize/select.tpl.html
+++ b/src/selectize/select.tpl.html
@@ -3,7 +3,7 @@
        ng-class="{'focus': $select.open, 'disabled': $select.disabled, 'selectize-focus' : $select.focus}"
        ng-click="$select.activate()">
     <div class="ui-select-match"></div>
-    <input type="text" autocomplete="false" tabindex="-1"
+    <input type="search" autocomplete="off" tabindex="-1"
            class="ui-select-search ui-select-toggle"
            ng-click="$select.toggle($event)"
            placeholder="{{$select.placeholder}}"


### PR DESCRIPTION
Chrome does not support the `autocomplete="off"` parameter on `<input type="text">` fields.
This PRs implements the suggested [workaround](https://code.google.com/p/chromium/issues/detail?id=468153#c33) by changing the type to `search`.

I also believe that this makes more sense semantically since the input is being used for filtering the results.