### PR TITLE
Ensure $select.selected exists prior to testing length.

### DIFF
--- a/src/uiSelectMultipleDirective.js
+++ b/src/uiSelectMultipleDirective.js
@@ -56,7 +56,7 @@ uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelec
 
       ctrl.getPlaceholder = function(){
         //Refactor single?
-        if($select.selected.length) return;
+        if($select.selected && $select.selected.length) return;
         return $select.placeholder;
       };
 


### PR DESCRIPTION
I have a use case where following exception is being thrown.  To be honest I do not totally understand the execution path, but handling this exception seems obvious enough.

```TypeError: Cannot read property 'length' of undefined
    at uis.directive.controller.ctrl.getPlaceholder```