### PR TITLE
New feature: allow displaying information when there is no record found

### DIFF
--- a/src/bootstrap/no-choice.tpl.html
+++ b/src/bootstrap/no-choice.tpl.html
@@ -1,0 +1,6 @@
+<ul class="ui-select-no-choice dropdown-menu"
+    ng-show="$select.items.length == 0">
+    <li ng-transclude>
+
+    </li>
+</ul>

--- a/src/bootstrap/select.tpl.html
+++ b/src/bootstrap/select.tpl.html
@@ -10,4 +10,5 @@
          ng-model="$select.search"
          ng-show="$select.searchEnabled && $select.open">
   <div class="ui-select-choices"></div>
+  <div class="ui-select-no-choice"></div>
 </div>

--- a/src/common.css
+++ b/src/common.css
@@ -148,7 +148,7 @@ body > .select2-container.open {
 }
 
 /* See Scrollable Menu with Bootstrap 3 http://stackoverflow.com/questions/19227496 */
-.ui-select-bootstrap > .ui-select-choices {
+.ui-select-bootstrap > .ui-select-choices ,.ui-select-bootstrap > .ui-select-no-choice {
   width: 100%;
   height: auto;
   max-height: 200px;

--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -186,6 +186,13 @@ uis.directive('uiSelect',
             throw uiSelectMinErr('transcluded', "Expected 1 .ui-select-choices but got '{0}'.", transcludedChoices.length);
           }
           element.querySelectorAll('.ui-select-choices').replaceWith(transcludedChoices);
+
+          var transcludedNoChoice = transcluded.querySelectorAll('.ui-select-no-choice');
+          transcludedNoChoice.removeAttr('ui-select-no-choice'); //To avoid loop in case directive as attr
+          transcludedNoChoice.removeAttr('data-ui-select-no-choice'); // Properly handle HTML5 data-attributes
+          if (transcludedNoChoice.length == 1) {
+            element.querySelectorAll('.ui-select-no-choice').replaceWith(transcludedNoChoice);
+          }
         });
 
         // Support for appending the select field to the body when its open

--- a/src/uiSelectNoChoiceDirective.js
+++ b/src/uiSelectNoChoiceDirective.js
@@ -1,0 +1,14 @@
+uis.directive('uiSelectNoChoice',
+    ['uiSelectConfig', function (uiSelectConfig) {
+        return {
+            restrict: 'EA',
+            require: '^uiSelect',
+            replace: true,
+            transclude: true,
+            templateUrl: function (tElement) {
+                // Gets theme attribute from parent (ui-select)
+                var theme = tElement.parent().attr('theme') || uiSelectConfig.theme;
+                return theme + '/no-choice.tpl.html';
+            }
+        };
+    }]);


### PR DESCRIPTION
I'm using ui-select in my project as it's a cool component. In my project, I really need the ability to show information when there is no record found. Looks like it's not implemented yet so I'm pushing this pull request for discussion.

I would like to create a separate directive (uiSelectNoChoice) to specify a template to be displayed when there is no record.

We can use it like this:
 ```
 <ui-select ng-model="address.selected"
             theme="bootstrap"
             ng-disabled="disabled"
             reset-search-input="false"
             style="width: 300px;"
             title="Choose an address">
    //remove others for a clearer view
    <ui-select-no-choice>
      <div style="text-align: center;">There is nothing to show</div>
    </ui-select-no-choice>
  </ui-select>
```

At the moment, I only implement it for bootstrap theme (for discussion purpose). If you guys think this is desirable and agree with the approach, we will go ahead with select2 and selectize theme.

Regards,
Khanh
