### PR TITLE
Bug/required multiple select

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 /node_modules
 /.idea
 /.tmp
-/dist
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /node_modules
 /.idea
 /.tmp
+/dist
 .DS_Store

--- a/examples/select2-bootstrap3.html
+++ b/examples/select2-bootstrap3.html
@@ -69,7 +69,7 @@
         <div class="col-sm-6">
 
           <ui-select multiple sortable="true" ng-model="person.selected" theme="select2" class="form-control" title="Choose a person">
-            <ui-select-match placeholder="Select or search a person in the list...">{{$select.selected.name}}</ui-select-match>
+            <ui-select-match placeholder="Select or search a person in the list...">{{$item.name}}</ui-select-match>
             <ui-select-choices repeat="item in people | filter: $select.search">
               <div ng-bind-html="item.name | highlight: $select.search"></div>
               <small ng-bind-html="item.email | highlight: $select.search"></small>

--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -57,6 +57,36 @@ uis.directive('uiSelect',
             element.removeAttr("tabindex");
           });
         }
+        
+        if (angular.isDefined(attrs.multiple) && angular.isDefined(attrs.required)) {
+          
+          // Custom validator to make required work with mulitple
+          // this pattern modeled after the way angular directly
+          // works with the requiredDirective
+          ngModel.$validators.uiRequired = function (modelValue, viewValue) {
+
+            // then we're dealing with multiple
+            if (Array.isArray(modelValue)) {
+              return modelValue.length > 0;
+            } else if (Array.isArray(viewValue)) {
+              return viewValue.length > 0;
+
+            // otherwise just check the direct model value
+            // for single selects
+            } else {
+              return modelValue !== undefined;
+            }
+
+            // we have to return a check directly.
+            // returning a variable can sometimes
+            // cause the check to return undefined
+            // to the $invalid and $valid properties
+            // due to the way angular parses the view.
+          };
+          attrs.$observe('required', function() {
+            ngModel.$validate();
+          });
+        }
 
         scope.$watch('searchEnabled', function() {
             var searchEnabled = scope.$eval(attrs.searchEnabled);


### PR DESCRIPTION
Closes the following:

https://github.com/angular-ui/ui-select/issues/850

and

https://github.com/angular-ui/ui-select/issues/914

The fix adds a custom validator to multiple selects that enables the `required` tag.  Custom validators are not "my" own customized way of doing things, they are the official angular way of writing validators as outlined in the Custom Validators section here https://docs.angularjs.org/guide/forms

The problem was that required checks the ngModel's viewModel, which when empty on a ui-select-multiple is an empty array...which is technically not empty.  Now it checks properly without interfering with the standard required validator.

Also fixed a test bug where $item.name wasn't being used in the multiple example.