### PR TITLE
Fix validating multiselect fields with 'required' attribute

### DIFF
--- a/src/uiSelectMultipleDirective.js
+++ b/src/uiSelectMultipleDirective.js
@@ -92,6 +92,10 @@ uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelec
         return resultMultiple;
       });
 
+      ngModel.$isEmpty = function () {
+        return !(angular.isArray(ngModel.$$rawModelValue) && ngModel.$$rawModelValue.length > 0);
+      };
+
       // From model --> view
       ngModel.$formatters.unshift(function (inputValue) {
         var data = $select.parserResult.source (scope, { $select : {search:''}}), //Overwrite $search

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -2102,6 +2102,25 @@ describe('ui-select tests', function() {
       expect(searchEl.length).toEqual(1);
       expect(searchEl[0].id).toEqual('inid');
     });
+
+    it('should be marked invalid when required and empty', function() {
+      scope.selection.selectedMultiple = [];
+      var el = createUiSelectMultiple({required: true});
+
+      expect(el.scope().$select.ngModel.$invalid).toEqual(true);
+      expect(el.scope().$select.ngModel.$error.required).toEqual(true);
+
+      clickItem(el, 'Samantha');
+
+      expect(el.scope().$select.ngModel.$invalid).toEqual(false);
+      expect(el.scope().$select.ngModel.$error.required).toEqual(undefined);
+
+      el.find('.ui-select-match-item').first().find('.ui-select-match-close').click();
+      $timeout.flush();
+
+      expect(el.scope().$select.ngModel.$invalid).toEqual(true);
+      expect(el.scope().$select.ngModel.$error.required).toEqual(true);
+    });
   });
 
   it('should add an id to the search input field', function () {


### PR DESCRIPTION
This PR makes 'required' attribute working with multiselect fields and fixes #258, #850 and #914. It overrides `ngModel.$isEmpty`, but unlike PR https://github.com/angular-ui/ui-select/pull/422 it handles the following scenario (https://github.com/angular-ui/ui-select/issues/258#issuecomment-64919605):

> 1. without selecting any thing ng-required work fine
> 2. select few element
> 3. removed all element from drop down
> 4. you see ng-required is not working any more now.

(See unit tests)
