### PR TITLE
Making sure atleast one items is highlighted before selecting on TAB

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -395,7 +395,9 @@ uis.controller('uiSelectCtrl',
         else if (ctrl.activeIndex > 0 || (ctrl.search.length === 0 && ctrl.tagging.isActivated && ctrl.activeIndex > -1)) { ctrl.activeIndex--; }
         break;
       case KEY.TAB:
-        if (!ctrl.multiple || ctrl.open) ctrl.select(ctrl.items[ctrl.activeIndex], true);
+        if ((!ctrl.multiple || ctrl.open) && ctrl.activeIndex >=0) {
+          ctrl.select(ctrl.items[ctrl.activeIndex], true); 
+        }
         break;
       case KEY.ENTER:
         if(ctrl.open && (ctrl.tagging.isActivated || ctrl.activeIndex >= 0)){


### PR DESCRIPTION
Current behaviour is, when user press TAB, ui-select is just triggering select() without checking if there is any activeIndex. If I do a clear, then there shouldn't be any highlighted item and it should not select when I press TAB. 

Please correct me if I am wrong