### PR TITLE
add onBeforeSelect callback

### DIFF
--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -41,6 +41,7 @@ uis.directive('uiSelect',
           }
         }();
 
+        $select.onBeforeSelectCallback = $parse(attrs.onBeforeSelect);
         $select.onSelectCallback = $parse(attrs.onSelect);
         $select.onRemoveCallback = $parse(attrs.onRemove);
         


### PR DESCRIPTION
Adds an onBeforeSelect callback to allow intercepting a selection. Ensures
access to both the prospective new selection and the current selection.

This is a preliminary offer for #1071 - let me know if you'd like any additional tests, style changes, etc.