### PR TITLE
Fix bug: If the taggingtoken is ',', the ',' should not be shown on the tagging label

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -447,6 +447,8 @@ uis.controller('uiSelectCtrl',
               }
               if (newItem) ctrl.select(newItem, true);
             });
+          e.preventDefault();
+          e.stopPropagation();
           }
         }
       }


### PR DESCRIPTION
If the taggingtoken is ',', the ',' should not be shown on the tagging label http://plnkr.co/edit/EK1CA5ANtVVtzwkfFGtk