### PR TITLE
Added open and close event hooks for directive

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -43,7 +43,7 @@ uis.controller('uiSelectCtrl',
   if (ctrl.searchInput.length !== 1) {
     throw uiSelectMinErr('searchInput', "Expected 1 input.ui-select-search but got '{0}'.", ctrl.searchInput.length);
   }
-  
+
   ctrl.isEmpty = function() {
     return angular.isUndefined(ctrl.selected) || ctrl.selected === null || ctrl.selected === '';
   };
@@ -513,6 +513,20 @@ uis.controller('uiSelectCtrl',
         container[0].scrollTop -= highlighted.clientHeight - posY;
     }
   }
+
+  $scope.$watch(function(){
+    return ctrl.open;
+  }, function(openState){
+    if(openState && ctrl.onOpenCallback){
+      ctrl.onOpenCallback($scope, {
+        $model: ctrl.parserResult.modelMapper($scope, {})
+      });
+    } else if (!openState && ctrl.onCloseCallback){
+      ctrl.onCloseCallback($scope, {
+        $model: ctrl.parserResult.modelMapper($scope, {})
+      });
+    }
+  });
 
   $scope.$on('$destroy', function() {
     ctrl.searchInput.off('keyup keydown tagged blur paste');

--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -21,7 +21,7 @@ uis.directive('uiSelect',
       if (angular.isDefined(tAttrs.multiple))
         tElement.append("<ui-select-multiple/>").removeAttr('multiple');
       else
-        tElement.append("<ui-select-single/>");       
+        tElement.append("<ui-select-single/>");
 
       return function(scope, element, attrs, ctrls, transcludeFn) {
 
@@ -43,7 +43,7 @@ uis.directive('uiSelect',
 
         $select.onSelectCallback = $parse(attrs.onSelect);
         $select.onRemoveCallback = $parse(attrs.onRemove);
-        
+
         //Limit the number of selections allowed
         $select.limit = (angular.isDefined(attrs.limit)) ? parseInt(attrs.limit, 10) : undefined;
 
@@ -293,6 +293,19 @@ uis.directive('uiSelect',
               element.removeClass(directionUpClassName);
           }
         });
+
+        attrs.$observe('uiSelectOnOpen', function() {
+          if (attrs.uiSelectOnOpen !== undefined) {
+            $select.onOpenCallback = $parse(attrs.uiSelectOnOpen);
+          }
+        });
+
+        attrs.$observe('uiSelectOnClose', function() {
+          if (attrs.uiSelectOnClose !== undefined) {
+            $select.onCloseCallback = $parse(attrs.uiSelectOnClose);
+          }
+        });
+
       };
     }
   };


### PR DESCRIPTION
Addresses a few of the feature requests in https://github.com/angular-ui/ui-select/issues/432

Specifically, directive APIs for onOpen and onClose callbacks.