### PR TITLE
Do not hide placeholder when multiple=true and some items are selected.

### DIFF
--- a/src/uiSelectMultipleDirective.js
+++ b/src/uiSelectMultipleDirective.js
@@ -55,8 +55,6 @@ uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelec
       };
 
       ctrl.getPlaceholder = function(){
-        //Refactor single?
-        if($select.selected && $select.selected.length) return;
         return $select.placeholder;
       };
 


### PR DESCRIPTION
For some reason, placeholder was hidden in scenario described in the title. It seems like an oversight.

##### Step 1
![ui-select1](https://cloud.githubusercontent.com/assets/44363/9553648/1be7142c-4dc9-11e5-9a40-a9f207659c72.png)

##### Step 2
![ui-select2](https://cloud.githubusercontent.com/assets/44363/9553651/21736080-4dc9-11e5-8343-d69d2949a521.png)

Now UX is a bit better, users don't have to wonder what is that big white empty area below selected items. :)