### PR TITLE
Avoid inline execution of javascript in choices template.

### DIFF
--- a/src/bootstrap/choices.tpl.html
+++ b/src/bootstrap/choices.tpl.html
@@ -4,9 +4,9 @@
   <li class="ui-select-choices-group" id="ui-select-choices-{{ $select.generatedId }}" >
     <div class="divider" ng-show="$select.isGrouped && $index > 0"></div>
     <div ng-show="$select.isGrouped" class="ui-select-choices-group-label dropdown-header" ng-bind="$group.name"></div>
-    <div id="ui-select-choices-row-{{ $select.generatedId }}-{{$index}}" class="ui-select-choices-row" 
+    <div id="ui-select-choices-row-{{ $select.generatedId }}-{{$index}}" class="ui-select-choices-row"
     ng-class="{active: $select.isActive(this), disabled: $select.isDisabled(this)}" role="option">
-      <a href="javascript:void(0)" class="ui-select-choices-row-inner"></a>
+      <a ng-click="$event.preventDefault()" class="ui-select-choices-row-inner"></a>
     </div>
   </li>
 </ul>


### PR DESCRIPTION
If a server sets the `content-security-policy` header to `script-src 'self' 'unsafe-inline';` all works well, but without `unsafe-unline`, the browser will throw an error: `Refused to execute JavaScript URL because it violates the following Content Security Policy directive:`.

There is no stack trace, but it turns out this is caused by `href="javascript:void(0)"` in the choices template. 

Pull request #395 proposed removing that piece Javascript altogether, but apparently there were side effects.

I'm replacing it with `ng-click="$event.preventDefault()"`, based on a similar fix in the [ui.bootstrap](https://github.com/angular-ui/bootstrap/commit/fb302c6086543420b3561be3ed5c49ac3974c243) project. This makes the CSP error go away.

All tests pass. I tried all examples in Safari and couldn't see anything obviously wrong, but I'm not sure what to look for.