### PR TITLE
fix(multiple): text input not resized on window resize

### DIFF
--- a/src/uiSelectMultipleDirective.js
+++ b/src/uiSelectMultipleDirective.js
@@ -1,4 +1,4 @@
-uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelectMinErr, $timeout) {
+uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', '$window', function(uiSelectMinErr, $timeout, $window) {
   return {
     restrict: 'EA',
     require: ['^uiSelect', '^ngModel'],
@@ -399,6 +399,14 @@ uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelec
         });
       });
 
+      function onWindowResize() {
+        $select.sizeSearchInput();
+      }
+
+      angular.element($window).on('resize', onWindowResize);
+      scope.$on('$destroy', function() {
+        angular.element($window).off('resize', null, onWindowResize);
+      });
     }
   };
 }]);


### PR DESCRIPTION
Text input within multiple select is not resized correctly on window resize. Open this plunkr and try to resize window. Notice that text input (with green background) is not resized:

http://embed.plnkr.co/cqsb8nOIunj2rMU36z5H/preview

Here's the demo with this fix applied: http://embed.plnkr.co/pPdeELl80hgCOVZKCs6a/preview