### PR TITLE
Dropdown can also be an empty array

### DIFF
--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -260,7 +260,7 @@ uis.directive('uiSelect',
         scope.$watch('$select.open', function(isOpen) {
           if (isOpen) {
             dropdown = angular.element(element).querySelectorAll('.ui-select-dropdown');
-            if (dropdown === null) {
+            if (dropdown.length === 0) {
               return;
             }
 
@@ -283,7 +283,7 @@ uis.directive('uiSelect',
               dropdown[0].style.opacity = 1;
             });
           } else {
-              if (dropdown === null) {
+              if (dropdown === null || dropdown.length === 0) {
                 return;
               }
 


### PR DESCRIPTION
It is dangerous to assume that `dropdown` will only be `null`. angular.element returns an empty array when no elements have been found.