### PR TITLE
refactor(choices): avoid setting activeItem on mouseenter

### DIFF
--- a/src/common.css
+++ b/src/common.css
@@ -17,6 +17,11 @@
   top: 0px !important;
 }
 
+
+.ui-select-choices-row:hover {
+  background-color: #f5f5f5;
+}
+
 /* Select2 theme */
 
 /* Mark invalid Select2 */

--- a/src/uiSelectChoicesDirective.js
+++ b/src/uiSelectChoicesDirective.js
@@ -41,7 +41,6 @@ uis.directive('uiSelectChoices',
 
         choices.attr('ng-repeat', RepeatParser.getNgRepeatExpression($select.parserResult.itemName, '$select.items', $select.parserResult.trackByExp, groupByExp))
             .attr('ng-if', '$select.open') //Prevent unnecessary watches when dropdown is closed
-            .attr('ng-mouseenter', '$select.setActiveItem('+$select.parserResult.itemName +')')
             .attr('ng-click', '$select.select(' + $select.parserResult.itemName + ',false,$event)');
 
         var rowsInner = element.querySelectorAll('.ui-select-choices-row-inner');

--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -198,10 +198,6 @@ uis.controller('uiSelectCtrl',
     }
   };
 
-  ctrl.setActiveItem = function(item) {
-    ctrl.activeIndex = ctrl.items.indexOf(item);
-  };
-
   ctrl.isActive = function(itemScope) {
     if ( !ctrl.open ) {
       return false;

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -959,35 +959,6 @@ describe('ui-select tests', function() {
 
   });
 
-  it('should invoke hover callback', function(){
-
-    var highlighted;
-    scope.onHighlightFn = function ($item) {
-      highlighted = $item;
-    };
-
-    var el = compileTemplate(
-      '<ui-select on-select="onSelectFn($item, $model)" ng-model="selection.selected"> \
-        <ui-select-match placeholder="Pick one...">{{$select.selected.name}}</ui-select-match> \
-        <ui-select-choices on-highlight="onHighlightFn(person)" repeat="person.name as person in people | filter: $select.search"> \
-          <div ng-bind-html="person.name | highlight: $select.search"></div> \
-          <div ng-bind-html="person.email | highlight: $select.search"></div> \
-        </ui-select-choices> \
-      </ui-select>'
-    );
-
-    expect(highlighted).toBeFalsy();
-
-    if (!isDropdownOpened(el)){
-      openDropdown(el);
-    }
-
-    $(el).find('.ui-select-choices-row div:contains("Samantha")').trigger('mouseover');
-    scope.$digest();
-
-    expect(highlighted).toBe(scope.people[5]);
-  });
-
   it('should set $item & $model correctly when invoking callback on select and no single prop. binding', function () {
 
     scope.onSelectFn = function ($item, $model, $label) {


### PR DESCRIPTION
We were using `ng-mouseenter` to be able to set the hovered row as the active item, but this caused some lagging as `ng-mouseenter` was calling for a full $digest.

Could be better just to show a simple hover background change (using css) and avoid doing a $digest.

Demo [plunker](http://plnkr.co/edit/1Nl9SBsc1yoxO3xDSZQk?p=preview)