### PR TITLE
ui-select-multiple choices are not refreshed after a ngModel update

### DIFF
--- a/src/uiSelectMultipleDirective.js
+++ b/src/uiSelectMultipleDirective.js
@@ -151,6 +151,7 @@ uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelec
           }
         }
         $select.selected = ngModel.$viewValue;
+        $selectMultiple.refreshComponent();
         scope.$evalAsync(); //To force $digest
       };
 


### PR DESCRIPTION
The watcher on ngModel.$modelValue is called before ngModel.$render. It means that $select.refreshItems() is called before $select.selected is updated (called through $selectMultiple.refreshComponent()).

This naive fix ensures that the component is refreshed after a model update. I suppose that there is a better way to do this by refactoring the ngModel event handling ($render is not doing any rendering, so that's an hint), but I don't have enough time to dig into what would be proper.

For those who would want an external fix, it is possible to work around the issue by manually updating $select.selected, e.g. angular.element('#myUISelectMultiple').controller('uiSelect').selected = myNewNgModelValue;
This should be called before the digest following the ngModel value is changed.