### PR TITLE
Variable element width support in multiple selections mode

### DIFF
--- a/examples/demo-multi-select.html
+++ b/examples/demo-multi-select.html
@@ -122,7 +122,7 @@
   <p>Selected: {{multipleDemo.colors}}</p>
   <hr>
   <h3>Array of objects (sorting enabled)</h3>
-  <ui-select multiple ng-model="multipleDemo.selectedPeople" theme="bootstrap" ng-disabled="disabled" sortable="true" close-on-select="false" style="width: 800px;">
+  <ui-select multiple ng-model="multipleDemo.selectedPeople" theme="bootstrap" ng-disabled="disabled" sortable="true" close-on-select="false">
     <ui-select-match placeholder="Select person...">{{$item.name}} &lt;{{$item.email}}&gt;</ui-select-match>
     <ui-select-choices repeat="person in people | propsFilter: {name: $select.search, age: $select.search}">
       <div ng-bind-html="person.name | highlight: $select.search"></div>
@@ -135,8 +135,8 @@
   <p>Selected: {{multipleDemo.selectedPeople}}</p>
 
   <hr>
-  <h3>Deselect callback with single property binding</h3>
-  <ui-select multiple ng-model="multipleDemo.deSelectedPeople" on-remove="removed($item, $model)" theme="bootstrap" ng-disabled="disabled" close-on-select="false" style="width: 800px;" title="Choose a person">
+  <h3>Deselect callback with single property binding (select2 theme)</h3>
+  <ui-select multiple ng-model="multipleDemo.deSelectedPeople" on-remove="removed($item, $model)" theme="select2" ng-disabled="disabled" close-on-select="false" title="Choose a person" style="min-width: 300px">
     <ui-select-match placeholder="Select person...">{{$item.name}} &lt;{{$item.email}}&gt;</ui-select-match>
     <ui-select-choices repeat="person.email as person in people | propsFilter: {name: $select.search, age: $select.search}">
       <div ng-bind-html="person.name | highlight: $select.search"></div>
@@ -150,8 +150,8 @@
   <p>Last removed model: {{lastRemoved.model}}</p>
 
   <hr>
-  <h3>Array of objects with single property binding</h3>
-  <ui-select multiple ng-model="multipleDemo.selectedPeopleSimple" theme="bootstrap" ng-disabled="disabled" close-on-select="false" style="width: 800px;" title="Choose a person">
+  <h3>Array of objects with single property binding (select2 theme)</h3>
+  <ui-select multiple ng-model="multipleDemo.selectedPeopleSimple" theme="select2" ng-disabled="disabled" close-on-select="false" title="Choose a person">
     <ui-select-match placeholder="Select person...">{{$item.name}} &lt;{{$item.email}}&gt;</ui-select-match>
     <ui-select-choices repeat="person.email as person in people | propsFilter: {name: $select.search, age: $select.search}">
       <div ng-bind-html="person.name | highlight: $select.search"></div>
@@ -165,7 +165,7 @@
 
   <hr>
   <h3>Array of objects (with groupBy)</h3>
-  <ui-select multiple ng-model="multipleDemo.selectedPeopleWithGroupBy" theme="bootstrap" ng-disabled="disabled" close-on-select="false" style="width: 800px;" title="Choose a person">
+  <ui-select multiple ng-model="multipleDemo.selectedPeopleWithGroupBy" theme="bootstrap" ng-disabled="disabled" close-on-select="false" title="Choose a person">
     <ui-select-match placeholder="Select person...">{{$item.name}} &lt;{{$item.email}}&gt;</ui-select-match>
     <ui-select-choices group-by="someGroupFn" repeat="person in people | propsFilter: {name: $select.search, age: $select.search}">
       <div ng-bind-html="person.name | highlight: $select.search"></div>

--- a/src/bootstrap/select-multiple.tpl.html
+++ b/src/bootstrap/select-multiple.tpl.html
@@ -1,5 +1,7 @@
-<div class="ui-select-container ui-select-multiple ui-select-bootstrap dropdown form-control" ng-class="{open: $select.open}">
-  <div>
+<div class="ui-select-container ui-select-multiple ui-select-bootstrap dropdown form-control"
+     ng-class="{open: $select.open, empty: !$select.selected.length}"
+     ng-click="$select.maybeActivate($event)">
+  <div ng-click="$select.maybeActivate($event)">
     <div class="ui-select-match"></div>
     <input type="text"
            autocomplete="false" 

--- a/src/common.css
+++ b/src/common.css
@@ -13,8 +13,8 @@
   overflow: hidden !important;
   position: absolute !important;
   outline: 0 !important;
-  left: 0px !important;
-  top: 0px !important;
+  left: 0 !important;
+  top: 0 !important;
 }
 
 
@@ -43,6 +43,10 @@
 
 body > .select2-container.open {
   z-index: 9999; /* The z-index Select2 applies to the select2-drop */
+}
+
+.select2-container-multi.empty .select2-search-field {
+  float: none;
 }
 
 /* Handle up direction Select2 */
@@ -163,6 +167,19 @@ body > .select2-container.open {
 
 body > .ui-select-bootstrap.open {
   z-index: 1000; /* Standard Bootstrap dropdown z-index */
+}
+
+.ui-select-multiple {
+  cursor: text;
+}
+
+.ui-select-multiple .ui-select-search {
+  width: 50px;
+  min-width: 50px;
+}
+
+.ui-select-multiple.empty .ui-select-search {
+  width: 100%;
 }
 
 .ui-select-multiple.ui-select-bootstrap {

--- a/src/select2/select-multiple.tpl.html
+++ b/src/select2/select-multiple.tpl.html
@@ -1,7 +1,9 @@
 <div class="ui-select-container ui-select-multiple select2 select2-container select2-container-multi"
      ng-class="{'select2-container-active select2-dropdown-open open': $select.open,
-                'select2-container-disabled': $select.disabled}">
-  <ul class="select2-choices">
+                'select2-container-disabled': $select.disabled,
+                'empty': !$select.selected.length}"
+     ng-click="$select.maybeActivate($event)">
+  <ul class="select2-choices" ng-click="$select.maybeActivate($event)">
     <span class="ui-select-match"></span>
     <li class="select2-search-field">
       <input
@@ -21,7 +23,6 @@
         ng-hide="$select.disabled"
         ng-model="$select.search"
         ng-click="$select.activate()"
-        style="width: 34px;"
         ondrop="return false;">
     </li>
   </ul>

--- a/src/uiSelectMatchDirective.js
+++ b/src/uiSelectMatchDirective.js
@@ -22,11 +22,6 @@ uis.directive('uiSelectMatch', ['uiSelectConfig', function(uiSelectConfig) {
 
       attrs.$observe('allowClear', setAllowClear);
       setAllowClear(attrs.allowClear);
-
-      if($select.multiple){
-        $select.sizeSearchInput();
-      }
-
     }
   };
 }]);

--- a/src/uiSelectMultipleDirective.js
+++ b/src/uiSelectMultipleDirective.js
@@ -24,7 +24,6 @@ uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelec
         //e.g. When user clicks on a selection, the selected array changes and 
         //the dropdown should remove that item
         $select.refreshItems();
-        $select.sizeSearchInput();
       };
 
       // Remove item from multiple select
@@ -40,7 +39,6 @@ uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelec
 
         $select.selected.splice(index, 1);
         ctrl.activeMatchIndex = -1;
-        $select.sizeSearchInput();
 
         // Give some time for scope propagation.
         $timeout(function(){
@@ -164,11 +162,11 @@ uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelec
 
       scope.$on('uis:activate', function () {
         $selectMultiple.activeMatchIndex = -1;
+        $select.sizeSearchInput();
       });
 
-      scope.$watch('$select.disabled', function(newValue, oldValue) {
-        // As the search input field may now become visible, it may be necessary to recompute its size
-        if (oldValue && !newValue) $select.sizeSearchInput();
+      scope.$on('uis:close', function() {
+        $select.searchInput.css('width', '');
       });
 
       $select.searchInput.on('keydown', function(e) {
@@ -187,6 +185,7 @@ uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelec
           }
         });
       });
+
       function _getCaretPosition(el) {
         if(angular.isNumber(el.selectionStart)) return el.selectionStart;
         // selectionStart is not supported in IE8 and we don't want hacky workarounds so we compromise

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -1578,20 +1578,6 @@ describe('ui-select tests', function() {
       expect($(el).attr('tabindex')).toEqual(undefined);
     });
 
-    it('should update size of search input after removing an item', function() {
-        scope.selection.selectedMultiple = [scope.people[4], scope.people[5]]; //Wladimir & Samantha
-        var el = createUiSelectMultiple();
-
-        spyOn(el.scope().$select, 'sizeSearchInput');
-
-        var searchInput = el.find('.ui-select-search');
-        var oldWidth = searchInput.css('width');
-
-        el.find('.ui-select-match-item').first().find('.ui-select-match-close').click();
-        expect(el.scope().$select.sizeSearchInput).toHaveBeenCalled();
-
-    });
-
     it('should move to last match when pressing BACKSPACE key from search', function() {
 
         var el = createUiSelectMultiple();


### PR DESCRIPTION
Currently, search input width maintained to take entire room available after selected items if there are. There are apparently two reasons to do that:
1. Show as much of search phrase as possible without getting on a new line
2. Catch all clicks to ui-select element to activate it (show dropdown, etc)

The search input size-related code is built on assumption that there are only internal sources of available room change, like adding or removing choices. That's mostly true if entire ui-select has fixed width. In other case if ui-select width is not fixed there are external things affecting it which we can't control, like parent container size change (due to window resize, for example), or dynamic styles changes (for example, choices might be hidden with css when dropdown is open).

This PR is aiming to make the element working better with variable width:

1. Reduce the time when search input is forced to have particular width to cover entire available room. Currently it's forced all the time. With the PR search input is only forcedly sized when ui-select is active. All other time it's sized with CSS. There are built-in `width` and `min-width` values which can be easily overridden in user code.

2. More accurately calculate available room for search input with respect to paddings. Get rid of magic numbers.

3. Catch clicks to the entire ui-select surface (free of current choices) to activate it. Currently, if element becomes multiline only clicks to the bottom line caught since that is where search input placed. Clicking on lines above does not take effect. PR fixes this.

4. Make examples in `demo-multi-select.html` having variable width. It seems there is no need to have them fixed-width now. The demo also shows how's the modified element working.