### PR TITLE
fix appendToBody focus on dropdown close #1003

### DIFF
--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -253,6 +253,9 @@ uis.directive('uiSelect',
           element[0].style.left = '';
           element[0].style.top = '';
           element[0].style.width = originalWidth;
+
+          // Set focus back on to the moved element
+          $select.setFocus();
         }
 
         // Hold on to a reference to the .ui-select-dropdown element for direction support.


### PR DESCRIPTION
When an appendToBody is true, the whole select field is literally moved within the DOM when the dropdown is triggered.  When the user has focus in the textbox, and the dropdown disappears, the textbox loses focus.

This is a problem when you have a user that is "delete" trigger happy, as they then navigate back in history.

This pull request sets focus on the dropdown text field when the dropdown disappears.