### PR TITLE
make highlight filter work with numeric items

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -133,7 +133,7 @@ var uis = angular.module('ui.select', [])
   }
 
   return function(matchItem, query) {
-    return query && matchItem ? matchItem.replace(new RegExp(escapeRegexp(query), 'gi'), '<span class="ui-select-highlight">$&</span>') : matchItem;
+    return query && matchItem ? ('' + matchItem).replace(new RegExp(escapeRegexp(query), 'gi'), '<span class="ui-select-highlight">$&</span>') : matchItem;
   };
 })
 

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -2254,4 +2254,33 @@ describe('ui-select tests', function() {
     });
   });
 
+  describe('highlight filter', function() {
+    var highlight;
+
+    beforeEach(function() {
+      highlight = $injector.get('highlightFilter');
+    });
+
+    it('returns the item if there is no match', function() {
+      var query = 'January';
+      var item = 'December';
+
+      expect(highlight(item, query)).toBe('December');
+    });
+
+    it('wraps search strings matches in ui-select-highlight class', function() {
+      var query = 'er';
+      var item = 'December';
+
+      expect(highlight(item, query)).toBe('Decemb<span class="ui-select-highlight">er</span>');
+    });
+
+    it('properly highlights numeric items', function() {
+      var query = '15';
+      var item = 2015;
+
+      expect(highlight(item, query)).toBe('20<span class="ui-select-highlight">15</span>');
+    });
+  });
+
 });


### PR DESCRIPTION
We had a bunch of exceptions caused by using the `highlight` filter on a list of years.  This PR casts numeric items to strings to fix this.  Includes a test to verify normal behavior and one verifying the fix.