### PR TITLE
Improve the paste handler to work even without tagging function.

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -45,6 +45,13 @@ var KEY = {
     },
     isHorizontalMovement: function (k){
       return ~[KEY.LEFT,KEY.RIGHT,KEY.BACKSPACE,KEY.DELETE].indexOf(k);
+    },
+    toSeparator: function (k) {
+      var sep = {ENTER:"\n",TAB:"\t",SPACE:" "}[k];
+      if (sep) return sep;
+      // return undefined for special keys other than enter, tab or space.
+      // no way to use them to cut strings.
+      return KEY[k] ? undefined : k;
     }
   };
 

--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -501,11 +501,8 @@ uis.controller('uiSelectCtrl',
       if (items && items.length > 0) {
         var oldsearch = ctrl.search;
         angular.forEach(items, function (item) {
-          item = item.trim();
-          if (item) {
-            ctrl.search = item;
-            ctrl.select(item, true);
-          }
+          ctrl.search = item;
+          ctrl.select(item, true);
         });
         ctrl.search = oldsearch;
         e.preventDefault();

--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -269,7 +269,7 @@ uis.controller('uiSelectCtrl',
   ctrl.select = function(item, skipFocusser, $event) {
     if (item === undefined || !item._uiSelectChoiceDisabled) {
 
-      if ( ! ctrl.items && ! ctrl.search ) return;
+      if ( ! ctrl.items && ! ctrl.search && ! ctrl.tagging.isActivated) return;
 
       if (!item || !item._uiSelectChoiceDisabled) {
         if(ctrl.tagging.isActivated) {
@@ -494,15 +494,20 @@ uis.controller('uiSelectCtrl',
   // If tagging try to split by tokens and add items
   ctrl.searchInput.on('paste', function (e) {
     var data = e.originalEvent.clipboardData.getData('text/plain');
-    if (data && data.length > 0 && ctrl.taggingTokens.isActivated && ctrl.tagging.fct) {
-      var items = data.split(ctrl.taggingTokens.tokens[0]); // split by first token only
+    if (data && data.length > 0 && ctrl.taggingTokens.isActivated) {
+      // split by first token only
+      var separator = KEY.toSeparator(ctrl.taggingTokens.tokens[0]);
+      var items = data.split(separator); 
       if (items && items.length > 0) {
+        var oldsearch = ctrl.search;
         angular.forEach(items, function (item) {
-          var newItem = ctrl.tagging.fct(item);
-          if (newItem) {
-            ctrl.select(newItem, true);
+          item = item.trim();
+          if (item) {
+            ctrl.search = item;
+            ctrl.select(item, true);
           }
         });
+        ctrl.search = oldsearch;
         e.preventDefault();
         e.stopPropagation();
       }

--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -307,7 +307,7 @@ uis.directive('uiSelect',
 
               if ($select.dropdownPosition === 'up'){
                   //Go UP
-                  setDropdownPosUp(offset, offsetDropdown);
+//                  setDropdownPosUp(offset, offsetDropdown);
 
               }else{ //AUTO
 

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -2096,6 +2096,22 @@ describe('ui-select tests', function() {
       expect($(el).scope().$select.selected.length).toBe(5);
     });
 
+    it('should split pastes on ENTER (and with undefined tagging function)', function() {
+      var el = createUiSelectMultiple({tagging: true, taggingTokens: "ENTER|,"});
+      clickMatch(el);
+      triggerPaste(el.find('input'), "tag1\ntag2\ntag3");
+
+      expect($(el).scope().$select.selected.length).toBe(3);
+    });
+
+    it('should split pastes on TAB', function() {
+      var el = createUiSelectMultiple({tagging: true, taggingTokens: "TAB|,"});
+      clickMatch(el);
+      triggerPaste(el.find('input'), "tag1\ttag2\ttag3");
+
+      expect($(el).scope().$select.selected.length).toBe(3);
+    });
+
     it('should add an id to the search input field', function () {
       var el = createUiSelectMultiple({inputId: 'inid'});
       var searchEl = $(el).find('input.ui-select-search');


### PR DESCRIPTION
This patch will improve copy&paste support. With this, it's no longer necessary to specify a scope function to be able to copy&paste into the ui-select field. copy&paste will now only require tagging.

Additionally, this improves tokenization handling. pasted data is now properly cut into pieces even when separator is ENTER, TAB or SPACE. Only splits the copy&paste with the first separator defined, though. The default is comma;