### PR TITLE
fix issue with tagging, when mouse click on options doesn't work for angular > 1.4.x

### DIFF
--- a/dist/select.js
+++ b/dist/select.js
@@ -1,7 +1,7 @@
 /*!
  * ui-select
  * http://github.com/angular-ui/ui-select
- * Version: 0.13.2 - 2015-10-09T15:34:24.040Z
+ * Version: 0.13.3 - 2015-11-30T12:23:16.040Z
  * License: MIT
  */
 
@@ -519,7 +519,7 @@ uis.controller('uiSelectCtrl',
               if (!item || angular.equals( ctrl.items[0], item ) ) {
                 return;
               }
-            } else {
+             } else if(!$event){  //if not mouse click, that done to prevent setting value by activeIndex 
               // keyboard nav happened first, user selected from dropdown
               item = ctrl.items[ctrl.activeIndex];
             }

--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -280,7 +280,7 @@ uis.controller('uiSelectCtrl',
               if (!item || angular.equals( ctrl.items[0], item ) ) {
                 return;
               }
-            } else {
+            } else if(!$event){  //if not mouse click, that done to prevent setting value by activeIndex 
               // keyboard nav happened first, user selected from dropdown
               item = ctrl.items[ctrl.activeIndex];
             }


### PR DESCRIPTION
There is problem for tagging with ang > 1.4.x , and 1.3.x.
It's only working with tagging-label="false"
https://github.com/angular-ui/ui-select/issues/983#issuecomment-109948338
Here is descrobed workaround with tagging-label="false".
But at the same time doesn't work choosing by mouse.
In this pull request fix for it
