### PR TITLE
Use ng-attr for placeholder

### DIFF
--- a/src/bootstrap/select-multiple.tpl.html
+++ b/src/bootstrap/select-multiple.tpl.html
@@ -2,12 +2,12 @@
   <div>
     <div class="ui-select-match"></div>
     <input type="text"
-           autocomplete="false" 
-           autocorrect="off" 
-           autocapitalize="off" 
-           spellcheck="false" 
+           autocomplete="false"
+           autocorrect="off"
+           autocapitalize="off"
+           spellcheck="false"
            class="ui-select-search input-xs"
-           placeholder="{{$selectMultiple.getPlaceholder()}}"
+           ng-attr-placeholder="{{$selectMultiple.getPlaceholder()}}"
            ng-disabled="$select.disabled"
            ng-hide="$select.disabled"
            ng-click="$select.activate()"

--- a/src/bootstrap/select.tpl.html
+++ b/src/bootstrap/select.tpl.html
@@ -6,7 +6,7 @@
          aria-owns="ui-select-choices-{{ $select.generatedId }}"
          aria-activedescendant="ui-select-choices-row-{{ $select.generatedId }}-{{ $select.activeIndex }}"
          class="form-control ui-select-search"
-         placeholder="{{$select.placeholder}}"
+         ng-attr-placeholder="{{$select.placeholder}}"
          ng-model="$select.search"
          ng-show="$select.searchEnabled && $select.open">
   <div class="ui-select-choices"></div>

--- a/src/select2/select-multiple.tpl.html
+++ b/src/select2/select-multiple.tpl.html
@@ -16,7 +16,7 @@
         aria-label="{{ $select.baseTitle }}"
         aria-activedescendant="ui-select-choices-row-{{ $select.generatedId }}-{{ $select.activeIndex }}"
         class="select2-input ui-select-search"
-        placeholder="{{$selectMultiple.getPlaceholder()}}"
+        ng-attr-placeholder="{{$selectMultiple.getPlaceholder()}}"
         ng-disabled="$select.disabled"
         ng-hide="$select.disabled"
         ng-model="$select.search"

--- a/src/selectize/select.tpl.html
+++ b/src/selectize/select.tpl.html
@@ -6,7 +6,7 @@
     <input type="text" autocomplete="false" tabindex="-1"
            class="ui-select-search ui-select-toggle"
            ng-click="$select.toggle($event)"
-           placeholder="{{$select.placeholder}}"
+           ng-attr-placeholder="{{$select.placeholder}}"
            ng-model="$select.search"
            ng-hide="!$select.searchEnabled || ($select.selected && !$select.open)"
            ng-disabled="$select.disabled"


### PR DESCRIPTION
The placeholder attr throws an error in IE10 and 11 (and maybe earlier versions?) and an easy solution is to use the ng-attr prefix. More info here: https://github.com/angular/angular.js/issues/5025

I visually validated that it works fine and ran gulp and all tests passed. I didn't include the updated dist files here because I didn't know what your process was but can happily do whatever you need.