### PR TITLE
Bug Fix: Selected items should not be removed when they are found to be invalid

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -200,7 +200,11 @@ uis.controller('uiSelectCtrl',
           //Remove already selected items (ex: while searching)
           //TODO Should add a test
           ctrl.refreshItems(items);
-          ctrl.ngModel.$modelValue = null; //Force scope model value and ngModel value to be out of sync to re-run formatters
+
+          //update the view value with fresh data from items, if there is a valid model value
+          if(angular.isDefined(ctrl.ngModel.$modelValue)) {
+            ctrl.ngModel.$modelValue = null; //Force scope model value and ngModel value to be out of sync to re-run formatters
+          }
         }
       }
     });

--- a/src/uiSelectMultipleDirective.js
+++ b/src/uiSelectMultipleDirective.js
@@ -135,7 +135,10 @@ uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelec
       //Watch for external model changes 
       scope.$watchCollection(function(){ return ngModel.$modelValue; }, function(newValue, oldValue) {
         if (oldValue != newValue){
-          ngModel.$modelValue = null; //Force scope model value and ngModel value to be out of sync to re-run formatters
+          //update the view value with fresh data from items, if there is a valid model value
+          if(angular.isDefined(ngModel.$modelValue)) {
+            ngModel.$modelValue = null; //Force scope model value and ngModel value to be out of sync to re-run formatters
+          }
           $selectMultiple.refreshComponent();
         }
       });

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -36,7 +36,37 @@ describe('ui-select tests', function() {
 
   });
 
-  beforeEach(module('ngSanitize', 'ui.select', 'wrapperDirective'));
+  /* Create a directive that can be applied to the ui-select instance to test
+   * the effects of Angular's validation process on the control.
+   *
+   * Does not currently work with single property binding. Looks at the
+   * selected object or objects for a "valid" property. If all selected objects
+   * have a "valid" property that is truthy, the validator passes.
+   */
+  angular.module('testValidator', []);
+  angular.module('testValidator').directive('testValidator', function() {
+    return {
+      restrict: 'A',
+      require: 'ngModel',
+      link: function(scope, element, attrs, ngModel) {
+        ngModel.$validators.testValidator = function(modelValue, viewValue) {
+          if(angular.isUndefined(modelValue) || modelValue === null) {
+            return true;
+          } else if(angular.isArray(modelValue)) {
+            var allValid = true, idx = modelValue.length;
+            while(idx-- > 0 && allValid) {
+              allValid = allValid && modelValue[idx].valid;
+            }
+            return allValid;
+          } else {
+            return !!modelValue.valid;
+          }
+        };
+      }
+    }
+  });
+
+  beforeEach(module('ngSanitize', 'ui.select', 'wrapperDirective', 'testValidator'));
 
   beforeEach(function() {
     module(function($provide) {
@@ -1433,6 +1463,45 @@ describe('ui-select tests', function() {
 
   });
 
+  it('should retain an invalid view value after refreshing items', function() {
+    scope.taggingFunc = function (name) {
+      return {
+        name: name,
+        email: name + '@email.com',
+        valid: name === "iamvalid"
+      };
+    };
+
+    var el = compileTemplate(
+        '<ui-select ng-model="selection.selected" tagging="taggingFunc" tagging-label="false" test-validator> \
+          <ui-select-match placeholder="Pick one...">{{$select.selected.email}}</ui-select-match> \
+          <ui-select-choices repeat="person in people | filter: $select.search"> \
+            <div ng-bind-html="person.name" | highlight: $select.search"></div> \
+            <div ng-bind-html="person.email | highlight: $select.search"></div> \
+          </ui-select-choices> \
+        </ui-select>'
+    );
+
+    clickMatch(el);
+    var searchInput = el.find('.ui-select-search');
+
+    setSearchText(el, 'iamvalid');
+    triggerKeydown(searchInput, Key.Tab);
+
+    //model value defined because it's valid, view value defined as expected
+    var validTag = scope.taggingFunc("iamvalid");
+    expect(scope.selection.selected).toEqual(validTag);
+    expect($(el).scope().$select.selected).toEqual(validTag);
+
+    clickMatch(el);
+    setSearchText(el, 'notvalid');
+    triggerKeydown(searchInput, Key.Tab);
+
+    //model value undefined because it's invalid, view value STILL defined as expected
+    expect(scope.selection.selected).toEqual(undefined);
+    expect($(el).scope().$select.selected).toEqual(scope.taggingFunc("notvalid"));
+  });
+
   describe('search-enabled option', function() {
 
     var el;
@@ -2018,6 +2087,45 @@ describe('ui-select tests', function() {
 
     });
 
+    it('should retain an invalid view value after refreshing items', function() {
+      scope.taggingFunc = function (name) {
+        return {
+          name: name,
+          email: name + '@email.com',
+          valid: name === "iamvalid"
+        };
+      };
+
+      var el = compileTemplate(
+          '<ui-select multiple ng-model="selection.selectedMultiple" tagging="taggingFunc" tagging-label="false" test-validator> \
+            <ui-select-match placeholder="Pick one...">{{$select.selected.email}}</ui-select-match> \
+            <ui-select-choices repeat="person in people | filter: $select.search"> \
+              <div ng-bind-html="person.name" | highlight: $select.search"></div> \
+              <div ng-bind-html="person.email | highlight: $select.search"></div> \
+            </ui-select-choices> \
+          </ui-select>'
+      );
+
+      clickMatch(el);
+      var searchInput = el.find('.ui-select-search');
+
+      setSearchText(el, 'iamvalid');
+      triggerKeydown(searchInput, Key.Tab);
+
+      //model value defined because it's valid, view value defined as expected
+      var validTag = scope.taggingFunc("iamvalid");
+      expect(scope.selection.selectedMultiple).toEqual([jasmine.objectContaining(validTag)]);
+      expect($(el).scope().$select.selected).toEqual([jasmine.objectContaining(validTag)]);
+
+      clickMatch(el);
+      setSearchText(el, 'notvalid');
+      triggerKeydown(searchInput, Key.Tab);
+
+      //model value undefined because it's invalid, view value STILL defined as expected
+      var invalidTag = scope.taggingFunc("notvalid");
+      expect(scope.selection.selected).toEqual(undefined);
+      expect($(el).scope().$select.selected).toEqual([jasmine.objectContaining(validTag), jasmine.objectContaining(invalidTag)]);
+    });
 
     it('should run $formatters when changing model directly', function () {
 


### PR DESCRIPTION
## A tagged item was getting removed accidentally in the following scenario:

### ui-select configuration:
- tagging

### problem code flow:
1. User enters tag text and accepts the new tag(s) (with tab or the like)
2. A validator determines that the tag is invalid, and sets the model value of the ui-select instance to undefined. At this point the view value still shows the invalid value.
3. The items list is refreshed during the tagging process, and is triggered after validators run. The items list on the uiSelectCtrl is updated.
4.  The item watcher sees the change and causes the view value to be updated from the model value, in order to reflect the data in the fresh items.
5. Since the model value is undefined until the invalid condition is resolved, the formatters run and create an empty view value, erasing the tagged item(s) - the user does not have an opportunity to resolve the invalid condition, their data is just erased.

### solution:
Do not update the view value on items refresh, when the model value is undefined