### PR TITLE
Fix angular.element.cache memory leak

### DIFF
--- a/src/uiSelectChoicesDirective.js
+++ b/src/uiSelectChoicesDirective.js
@@ -61,6 +61,10 @@ uis.directive('uiSelectChoices',
 
         $compile(element, transcludeFn)(scope); //Passing current transcludeFn to be able to append elements correctly from uisTranscludeAppend
 
+        scope.$on('$destroy', function() {
+          choices.remove();
+        });
+
         scope.$watch('$select.search', function(newValue) {
           if(newValue && !$select.open && $select.multiple) $select.activate(false, true);
           $select.activeIndex = $select.tagging.isActivated ? -1 : 0;

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -321,6 +321,13 @@ describe('ui-select tests', function() {
 
   });
 
+  it('should not leak memory', function() {
+    var cacheLenght = Object.keys(angular.element.cache).length;
+    createUiSelect().remove();
+    scope.$destroy();
+    expect(Object.keys(angular.element.cache).length).toBe(cacheLenght);
+  });
+
   it('should compile child directives', function() {
     var el = createUiSelect();
 


### PR DESCRIPTION
After doing memory leak hunting in my application I found that ui-select is leaking memory. I'm not sure why this is exactly needed as I would have expected $compile to handle it (I tried looking at uiSelectDirective.js with no results)