### PR TITLE
chore(sourcemaps): Use gulp-sourcemaps to generate sourcemaps for minified files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,6 +2,7 @@ var fs = require('fs');
 var gulp = require('gulp');
 var karma = require('karma').server;
 var concat = require('gulp-concat');
+var sourcemaps = require('gulp-sourcemaps');
 var jshint = require('gulp-jshint');
 var header = require('gulp-header');
 var footer = require('gulp-footer');
@@ -72,8 +73,10 @@ gulp.task('scripts', ['clean'], function() {
       timestamp: (new Date()).toISOString(), pkg: config.pkg
     }))
     .pipe(gulp.dest('dist'))
+    .pipe(sourcemaps.init())
     .pipe(uglify({preserveComments: 'some'}))
     .pipe(rename({ext:'.min.js'}))
+    .pipe(sourcemaps.write('./'))
     .pipe(gulp.dest('dist'));
 
 });
@@ -86,8 +89,10 @@ gulp.task('styles', ['clean'], function() {
     }))
     .pipe(rename('select.css'))
     .pipe(gulp.dest('dist'))
+    .pipe(sourcemaps.init())
     .pipe(minifyCSS())
     .pipe(rename({ext:'.min.css'}))
+    .pipe(sourcemaps.write('./'))
     .pipe(gulp.dest('dist'));
 
 });

--- a/package.json
+++ b/package.json
@@ -14,23 +14,24 @@
     "gulp": "~3.8.5",
     "gulp-angular-templatecache": "~1.2.1",
     "gulp-concat": "~2.1.7",
-    "gulp-header": "~1.0.2",
     "gulp-footer": "~1.0.5",
+    "gulp-header": "~1.0.2",
     "gulp-jshint": "1.6.4",
     "gulp-minify-css": "~0.3.6",
     "gulp-minify-html": "~0.1.0",
     "gulp-plumber": "^0.6.3",
     "gulp-rename": "~0.2.2",
+    "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "~0.3.1",
     "gulp-util": "^2.2.19",
     "jshint-stylish": "~0.3.0",
     "karma": "^0.12.16",
     "karma-chrome-launcher": "^0.1.3",
+    "karma-coverage": "~0.2",
     "karma-firefox-launcher": "~0.1",
     "karma-jasmine": "~0.2",
     "karma-ng-html2js-preprocessor": "^0.1.0",
-    "karma-phantomjs-launcher": "~0.1.4",
-    "karma-coverage": "~0.2"
+    "karma-phantomjs-launcher": "~0.1.4"
   },
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
Fixes #1107 

Uses [gulp-sourcemaps](https://github.com/floridoo/gulp-sourcemaps) plugin to generate the sourcemaps for the minified JavaScript and CSS file 