### PR TITLE
Fix RTL support when using tagging - calculate right input width

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -391,7 +391,21 @@ uis.controller('uiSelectCtrl',
           if (containerWidth === 0) {
             return false;
           }
-          var inputWidth = containerWidth - input.offsetLeft - 10;
+          
+          // Check if document is rtl
+          var isRTL = angular.element('html[dir="rtl"]').length > 0,
+              inputWidth;
+
+          // If document is RTL - calculate offset right
+          if (isRTL) {
+            var offsetRight = containerWidth - (input.offsetLeft + ctrl.searchInput.outerWidth());
+            inputWidth = containerWidth - offsetRight - 10;
+          }
+
+          else {
+            inputWidth = containerWidth - input.offsetLeft - 10;
+          }
+          
           if (inputWidth < 50) inputWidth = containerWidth;
           ctrl.searchInput.css('width', inputWidth+'px');
           return true;


### PR DESCRIPTION
Hi. 
Just noticed that there's a "bug" when using the tagging option within an RTL document.
The width of the input wasn't calculated like it should. 
This pull request fixes it.