### PR TITLE
onMatchClick callback

### DIFF
--- a/src/bootstrap/match-multiple.tpl.html
+++ b/src/bootstrap/match-multiple.tpl.html
@@ -1,11 +1,11 @@
 <span class="ui-select-match">
   <span ng-repeat="$item in $select.selected">
-    <span 
+    <span
       class="ui-select-match-item btn btn-default btn-xs"
       tabindex="-1"
       type="button"
       ng-disabled="$select.disabled"
-      ng-click="$selectMultiple.activeMatchIndex = $index;"
+      ng-click="$selectMultiple.setActiveMatch($index);"
       ng-class="{'btn-primary':$selectMultiple.activeMatchIndex === $index, 'select-locked':$select.isLocked(this, $index)}"
       ui-select-sort="$select.selected">
         <span class="close ui-select-match-close" ng-hide="$select.disabled" ng-click="$selectMultiple.removeChoice($index)">&nbsp;&times;</span>

--- a/src/select2/match-multiple.tpl.html
+++ b/src/select2/match-multiple.tpl.html
@@ -4,7 +4,7 @@
   do not work: [class^="select2-choice"]
 -->
 <span class="ui-select-match">
-  <li class="ui-select-match-item select2-search-choice" ng-repeat="$item in $select.selected" 
+  <li class="ui-select-match-item select2-search-choice" ng-repeat="$item in $select.selected" ng-click="$selectMultiple.setActiveMatch($index);"
       ng-class="{'select2-search-choice-focus':$selectMultiple.activeMatchIndex === $index, 'select2-locked':$select.isLocked(this, $index)}"
       ui-select-sort="$select.selected">
       <span uis-transclude-append></span>

--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -58,6 +58,7 @@ uis.directive('uiSelect',
         });
 
         $select.onSelectCallback = $parse(attrs.onSelect);
+        $select.onMatchClickCallback = $parse(attrs.onMatchClick);
         $select.onRemoveCallback = $parse(attrs.onRemove);
 
         //Limit the number of selections allowed

--- a/src/uiSelectMultipleDirective.js
+++ b/src/uiSelectMultipleDirective.js
@@ -30,6 +30,22 @@ uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelec
         $select.sizeSearchInput();
       };
 
+      //sets selected match index as new activeMatchIndex and triggers callback
+      ctrl.setActiveMatch = function(index) {
+        ctrl.activeMatchIndex = index;
+        var item = $select.selected[ctrl.activeMatchIndex];
+        if(item) {
+          var locals = {};
+          locals[$select.parserResult.itemName] = item;
+          $timeout(function () {
+            $select.onMatchClickCallback($scope, {
+              $item: item,
+              $model: $select.parserResult.modelMapper($scope, locals)
+            });
+          });
+        }
+      };
+
       // Remove item from multiple select
       ctrl.removeChoice = function(index){
 

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -1262,6 +1262,43 @@ describe('ui-select tests', function() {
 
   });
 
+  it('should invoke match click callback when click on a match', function () {
+
+    scope.onMatchClickFn = function ($item, $model, $label) {
+      scope.$item = $item;
+      scope.$model = $model;
+    };
+    var el = compileTemplate(
+      '<ui-select multiple on-match-click="onMatchClickFn($item, $model)" ng-model="selection.selected"> \
+        <ui-select-match placeholder="Pick one...">{{$select.selected.name}}</ui-select-match> \
+        <ui-select-choices repeat="person.name as person in people | filter: $select.search"> \
+          <div ng-bind-html="person.name | highlight: $select.search"></div> \
+          <div ng-bind-html="person.email | highlight: $select.search"></div> \
+        </ui-select-choices> \
+      </ui-select>'
+    );
+
+    expect(scope.$item).toBeFalsy();
+    expect(scope.$model).toBeFalsy();
+
+    clickItem(el, 'Samantha');
+    clickItem(el, 'Adrian');
+    clickItem(el, 'Nicole');
+    $timeout.flush();
+
+    el.find('.ui-select-match-item').first().click();
+    $timeout.flush();
+
+    expect(scope.$item).toBe(scope.people[5]);
+    expect(scope.$model).toBe('Samantha');
+
+    el.find('.ui-select-match-item').last().click();
+    $timeout.flush();
+
+    expect(scope.$item).toBe(scope.people[6]);
+    expect(scope.$model).toBe('Nicole');
+  });
+
   it('should set $item & $model correctly when invoking callback on remove and no single prop. binding', function () {
 
     scope.onRemoveFn = function ($item, $model, $label) {


### PR DESCRIPTION
When using ui-select-multiple there was no way to add a callback to be triggered when a user clicks on one of the matches. I added a on-match-click event to the directive that behaves like on-elect and on-remove.