### PR TITLE
hide clear button if disabled

### DIFF
--- a/src/bootstrap/match.tpl.html
+++ b/src/bootstrap/match.tpl.html
@@ -8,7 +8,7 @@
     <span ng-show="$select.isEmpty()" class="ui-select-placeholder text-muted">{{$select.placeholder}}</span>
     <span ng-hide="$select.isEmpty()" class="ui-select-match-text pull-left" ng-class="{'ui-select-allow-clear': $select.allowClear && !$select.isEmpty()}" ng-transclude=""></span>
     <i class="caret pull-right" ng-click="$select.toggle($event)"></i>
-    <a ng-show="$select.allowClear && !$select.isEmpty()" aria-label="{{ $select.baseTitle }} clear" style="margin-right: 10px" 
+    <a ng-show="$select.allowClear && !$select.isEmpty() && ($select.disabled !== true)" aria-label="{{ $select.baseTitle }} clear" style="margin-right: 10px" 
       ng-click="$select.clear($event)" class="btn btn-xs btn-link pull-right">
       <i class="glyphicon glyphicon-remove" aria-hidden="true"></i>
     </a>


### PR DESCRIPTION
This addresses this issue: https://github.com/angular-ui/ui-select/issues/980 
> Clear button shown on disabled select

This will hide the clear button if $select.disabled is true.