### PR TITLE
Fix _findApproxDupe when using tagging function and property binding features together on iuSelectMultiple.

### DIFF
--- a/src/uiSelectMultipleDirective.js
+++ b/src/uiSelectMultipleDirective.js
@@ -383,7 +383,7 @@ uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelec
             // handle the object tagging implementation
             } else {
               var mockObj = tempArr[i];
-              if (angular.isObject(mockObj) {
+              if (angular.isObject(mockObj)) {
                 mockObj.isTag = true;
               }
               if ( angular.equals(mockObj, needle) ) {

--- a/src/uiSelectMultipleDirective.js
+++ b/src/uiSelectMultipleDirective.js
@@ -383,9 +383,11 @@ uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelec
             // handle the object tagging implementation
             } else {
               var mockObj = tempArr[i];
-              mockObj.isTag = true;
+              if (angular.isObject(mockObj) {
+                mockObj.isTag = true;
+              }
               if ( angular.equals(mockObj, needle) ) {
-              dupeIndex = i;
+                dupeIndex = i;
               }
             }
           }


### PR DESCRIPTION
A bug was caused when _findApproxDupe was trying to set "isTag" property on a privitive value (e.g. String). These types of values are received when $select.selected holds an array of privitive values (using key binding).

**Link to a [proof of concept](http://plnkr.co/edit/yCGBkcsfl6m9ib4Tuyo4?p=preview)**