### PR TITLE
fix: make compatible with Angular 1.5 and non-cached templates

### DIFF
--- a/src/uiSelectChoicesDirective.js
+++ b/src/uiSelectChoicesDirective.js
@@ -8,6 +8,9 @@ uis.directive('uiSelectChoices',
     replace: true,
     transclude: true,
     templateUrl: function(tElement) {
+      // Needed so the uiSelect can detect the transcluded content
+      tElement.addClass('ui-select-choices');
+
       // Gets theme attribute from parent (ui-select)
       var theme = tElement.parent().attr('theme') || uiSelectConfig.theme;
       return theme + '/choices.tpl.html';

--- a/src/uiSelectMatchDirective.js
+++ b/src/uiSelectMatchDirective.js
@@ -5,6 +5,9 @@ uis.directive('uiSelectMatch', ['uiSelectConfig', function(uiSelectConfig) {
     replace: true,
     transclude: true,
     templateUrl: function(tElement) {
+      // Needed so the uiSelect can detect the transcluded content
+      tElement.addClass('ui-select-match');
+
       // Gets theme attribute from parent (ui-select)
       var theme = tElement.parent().attr('theme') || uiSelectConfig.theme;
       var multi = tElement.parent().attr('multiple');

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -967,6 +967,7 @@ describe('ui-select tests', function() {
     expect(function() {
       compileTemplate(
         '<ui-select ng-model="selection.selected"> \
+          <ui-select-match></ui-select-match> \
           <ui-select-choices></ui-select-choices> \
         </ui-select>'
       );


### PR DESCRIPTION
In Angular 1.5, transcluded content is linked lazily.
For uiSelect that means the clone in the transclude function is not compiled and linked yet, so
uiSelect cannot detect the match and choices elements by their classnames, because they haven't been
set yet (which happens by replacing the elements with the templates).
However, the templateUrl function is executed at this point, so we can use it to add the
class names to the directive elements.

On another note, this behavior also affected versions earlier than 1.5.0-beta.2, when the template
of ui-select-match or ui-select-choices wasn't cached. In that case, the async compilation of
the template would mean also that the clone in the transclude function wasn't compiled yet, and so
the classes wouldn't be set either.

Closes #1422
Closes #1356
Closes #1325
Closes #1239