### PR TITLE
fix: Allow setting a ngClass on <ui-select> element

### DIFF
--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -17,6 +17,14 @@ uis.directive('uiSelect',
     controllerAs: '$select',
     compile: function(tElement, tAttrs) {
 
+      // Allow setting ngClass on uiSelect
+      var match = /{(.*)}\s*{(.*)}/.exec(tAttrs.ngClass);
+      if(match) {
+        var combined = '{'+ match[1] +', '+ match[2] +'}';
+        tAttrs.ngClass = combined;
+        tElement.attr('ng-class', combined);
+      }
+
       //Multiple or Single depending if multiple attribute presence
       if (angular.isDefined(tAttrs.multiple))
         tElement.append('<ui-select-multiple/>').removeAttr('multiple');


### PR DESCRIPTION
Since a ngClass is already present in the uiSelect theme templates, we could not add any ngClass on <ui-select> without getting an JS error
Currently, adding a ngClass on <ui-select> result in:
`ng-class="{class: expression} {open: $select.open}"`
With this fix, doing the same thing result in:
`ng-class="{class: expression, open: $select.open}"`

Closes #277

Maybe I should write a test case ?