### PR TITLE
test(uiSelectDirective): Add test when merging ngClass attributes on uiSelect

### DIFF
--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -128,6 +128,7 @@ describe('ui-select tests', function() {
       if (attrs.appendToBody !== undefined) { attrsHtml += ' append-to-body="' + attrs.appendToBody + '"'; }
       if (attrs.allowClear !== undefined) { matchAttrsHtml += ' allow-clear="' + attrs.allowClear + '"';}
       if (attrs.inputId !== undefined) { attrsHtml += ' input-id="' + attrs.inputId + '"'; }
+      if (attrs.ngClass !== undefined) { attrsHtml += ' ng-class="' + attrs.ngClass + '"'; }
     }
 
     return compileTemplate(
@@ -347,6 +348,14 @@ describe('ui-select tests', function() {
     var el = createUiSelect();
 
     expect(getMatchLabel(el)).toEqual('Adam');
+  });
+
+  it('should merge both ng-class attributes defined on ui-select and its templates', function() {
+    var el = createUiSelect({
+      ngClass: "{class: expression}"
+    });
+
+    expect($(el).attr('ng-class')).toEqual("{class: expression, open: $select.open}");
   });
 
   it('should correctly render initial state with track by feature', function() {


### PR DESCRIPTION
References PR #1447
- Add missing test on uiSelect when merging ngClass attributes between DOM declaration and template
- Add one property `attrs.ngClass` in `createUiSelect(attrs)` to append a `ng-class` attribute to the `<ui-select>` element