### PR TITLE
Fix: Made the ENTER key work for tagging in single (non-multiple) mode

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -506,7 +506,6 @@ uis.controller('uiSelectCtrl',
       var tagged = false;
 
       if (ctrl.items.length > 0 || ctrl.tagging.isActivated) {
-        _handleDropDownSelection(key);
         if ( ctrl.taggingTokens.isActivated ) {
           for (var i = 0; i < ctrl.taggingTokens.tokens.length; i++) {
             if ( ctrl.taggingTokens.tokens[i] === KEY.MAP[e.keyCode] ) {
@@ -526,6 +525,9 @@ uis.controller('uiSelectCtrl',
               if (newItem) ctrl.select(newItem, true);
             });
           }
+        }
+        if ( !tagged ) {
+          _handleDropDownSelection(key);
         }
       }
 


### PR DESCRIPTION
When tagging is enabled (and in non-multiple mode), the ENTER key was processed first under the _handleDropDownSelection, invalidating the selection for a new tag. 

You can see this failing in examples/demo-tagging.html, in the last two examples: "Tagging without multiple" and "Tagging without multiple, with simple strings". They both fail for new tags when user types the ENTER key to add a new tag. 

With this proposed fix that issue is resolved. The _handleDropDownSelection should only be called if no new tag is detected.