### PR TITLE
Updated choices.tpl.html to properly hide and show dropdown

### DIFF
--- a/src/bootstrap/choices.tpl.html
+++ b/src/bootstrap/choices.tpl.html
@@ -1,6 +1,6 @@
 <ul class="ui-select-choices ui-select-choices-content ui-select-dropdown dropdown-menu"
     role="listbox"
-    ng-show="$select.items.length > 0">
+    ng-show="$select.open">
   <li class="ui-select-choices-group" id="ui-select-choices-{{ $select.generatedId }}" >
     <div class="divider" ng-show="$select.isGrouped && $index > 0"></div>
     <div ng-show="$select.isGrouped" class="ui-select-choices-group-label dropdown-header" ng-bind="$group.name"></div>


### PR DESCRIPTION
In some cases dropdown is shown even when it is not open. That's because ng-show is bound to $select.items, that may be not empty.