### PR TITLE
Fix(templates): Autocomplete=false does not work in Edge

### DIFF
--- a/src/bootstrap/select-multiple.tpl.html
+++ b/src/bootstrap/select-multiple.tpl.html
@@ -2,7 +2,7 @@
   <div>
     <div class="ui-select-match"></div>
     <input type="text"
-           autocomplete="false" 
+           autocomplete="off" 
            autocorrect="off" 
            autocapitalize="off" 
            spellcheck="false" 

--- a/src/bootstrap/select.tpl.html
+++ b/src/bootstrap/select.tpl.html
@@ -1,6 +1,6 @@
 <div class="ui-select-container ui-select-bootstrap dropdown" ng-class="{open: $select.open}">
   <div class="ui-select-match"></div>
-  <input type="text" autocomplete="false" tabindex="-1"
+  <input type="text" autocomplete="off" tabindex="-1"
          aria-expanded="true"
          aria-label="{{ $select.baseTitle }}"
          aria-owns="ui-select-choices-{{ $select.generatedId }}"

--- a/src/select2/select-multiple.tpl.html
+++ b/src/select2/select-multiple.tpl.html
@@ -6,7 +6,7 @@
     <li class="select2-search-field">
       <input
         type="text"
-        autocomplete="false"
+        autocomplete="off"
         autocorrect="off"
         autocapitalize="off"
         spellcheck="false"

--- a/src/select2/select.tpl.html
+++ b/src/select2/select.tpl.html
@@ -7,7 +7,7 @@
   <div class="ui-select-dropdown select2-drop select2-with-searchbox select2-drop-active"
        ng-class="{'select2-display-none': !$select.open}">
     <div class="select2-search" ng-show="$select.searchEnabled">
-      <input type="text" autocomplete="false" autocorrect="false" autocapitalize="off" spellcheck="false"
+      <input type="text" autocomplete="off" autocorrect="false" autocapitalize="off" spellcheck="false"
        role="combobox"
        aria-expanded="true"
        aria-owns="ui-select-choices-{{ $select.generatedId }}"

--- a/src/selectize/select.tpl.html
+++ b/src/selectize/select.tpl.html
@@ -3,7 +3,7 @@
        ng-class="{'focus': $select.open, 'disabled': $select.disabled, 'selectize-focus' : $select.focus}"
        ng-click="$select.open && !$select.searchEnabled ? $select.toggle($event) : $select.activate()">
     <div class="ui-select-match"></div>
-    <input type="text" autocomplete="false" tabindex="-1"
+    <input type="text" autocomplete="off" tabindex="-1"
            class="ui-select-search ui-select-toggle"
            ng-click="$select.toggle($event)"
            placeholder="{{$select.placeholder}}"


### PR DESCRIPTION
Edge browser showed autocomplete with autocomplete=false Standard states
it should be autocomplete=off which works currently with Chrome too.

Closes #1346