### PR TITLE
fix the PR #1208 which had broken the multiple selection ordered by groups

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -135,6 +135,9 @@ uis.controller('uiSelectCtrl',
       } else {
         $timeout(function () {
           ctrl.focusSearchInput(initSearchValue);
+          if(!ctrl.tagging.isActivated && ctrl.items.length > 1) {
+            _ensureHighlightVisible();
+          }
         });
       }
     }
@@ -143,9 +146,6 @@ uis.controller('uiSelectCtrl',
   ctrl.focusSearchInput = function (initSearchValue) {
     ctrl.search = initSearchValue || ctrl.search;
     ctrl.searchInput[0].focus();
-    if(!ctrl.tagging.isActivated && ctrl.items.length > 1) {
-     _ensureHighlightVisible();
-    }
   };
 
   ctrl.findGroupByName = function(name) {


### PR DESCRIPTION
The dropdown was going back to the activated element ('A' for instance) when the user clicked on the 'X' element, which was quite annoying when he wanted to select also Y and Z

cf #976