### PR TITLE
fix(uiSelectCtrl): correcting input focus

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -123,15 +123,29 @@ uis.controller('uiSelectCtrl',
       }
 
       var container = $element.querySelectorAll('.ui-select-choices-content');
-      if (ctrl.$animate && ctrl.$animate.on && ctrl.$animate.enabled(container[0])) {
-        ctrl.$animate.on('enter', container[0], function (elem, phase) {
-          if (phase === 'close') {
+      var searchInput = $element.querySelectorAll('.ui-select-search');
+      if (ctrl.$animate && ctrl.$animate.enabled(container[0])) {
+        var animateHandler = function(elem, phase) {
+          if (phase === 'start' && ctrl.items.length === 0) {
             // Only focus input after the animation has finished
             $timeout(function () {
+              ctrl.$animate.off('removeClass', searchInput[0], animateHandler);
+              ctrl.focusSearchInput(initSearchValue);
+            });
+          } else if (phase === 'close') {
+            // Only focus input after the animation has finished
+            $timeout(function () {
+              ctrl.$animate.off('enter', container[0], animateHandler);
               ctrl.focusSearchInput(initSearchValue);
             });
           }
-        });
+        };
+
+        if (ctrl.items.length > 0) {
+          ctrl.$animate.on('enter', container[0], animateHandler);
+        } else {
+          ctrl.$animate.on('removeClass', searchInput[0], animateHandler);
+        }
       } else {
         $timeout(function () {
           ctrl.focusSearchInput(initSearchValue);

--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -128,14 +128,14 @@ uis.controller('uiSelectCtrl',
         var animateHandler = function(elem, phase) {
           if (phase === 'start' && ctrl.items.length === 0) {
             // Only focus input after the animation has finished
+            ctrl.$animate.off('removeClass', searchInput[0], animateHandler);
             $timeout(function () {
-              ctrl.$animate.off('removeClass', searchInput[0], animateHandler);
               ctrl.focusSearchInput(initSearchValue);
             });
           } else if (phase === 'close') {
             // Only focus input after the animation has finished
+            ctrl.$animate.off('enter', container[0], animateHandler);
             $timeout(function () {
-              ctrl.$animate.off('enter', container[0], animateHandler);
               ctrl.focusSearchInput(initSearchValue);
             });
           }


### PR DESCRIPTION
Corrected input focus when ui-select contains no elements. Also corrected a memory leaked caused by event handlers never being removed.

Closes #1253