### PR TITLE
feat(perf): optimize width resizing

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -444,6 +444,7 @@ uis.controller('uiSelectCtrl',
   };
 
   var sizeWatch = null;
+  var updaterScheduled = false;
   ctrl.sizeSearchInput = function() {
 
     var input = ctrl.searchInput[0],
@@ -465,10 +466,16 @@ uis.controller('uiSelectCtrl',
     ctrl.searchInput.css('width', '10px');
     $timeout(function() { //Give tags time to render correctly
       if (sizeWatch === null && !updateIfVisible(calculateContainerWidth())) {
-        sizeWatch = $scope.$watch(calculateContainerWidth, function(containerWidth) {
-          if (updateIfVisible(containerWidth)) {
-            sizeWatch();
-            sizeWatch = null;
+        sizeWatch = $scope.$watch(angular.noop, function() {
+          if (!updaterScheduled) {
+            updaterScheduled = true;
+            $scope.$$postDigest(function() {
+              updaterScheduled = false;
+              if (updateIfVisible(calculateContainerWidth())) {
+                sizeWatch();
+                sizeWatch = null;
+              }
+            });
           }
         });
       }


### PR DESCRIPTION
- Optimize running dynamic width calculations when resizing

This is not the right way for updates to be made to the input size in general, but this is a vast improvement over the current method. The improvement here is that it does not touch the DOM until after everything stabilizes in the dirty checking loop, so it avoids the expensive DOM check in the watch expression callback until the end.