### PR TITLE
chore(ci) remove bower dev references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ addons:
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - npm install --quiet -g gulp
-  - bower install
+  - npm install --quiet -g gulp  
 
 script: "gulp test"
 sudo: false

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Make sure composer is install globally before we proceed. After that we need to 
 ### Prepare your environment
 * Install [Node.js](http://nodejs.org/) and NPM (should come with)
 * Install global dev dependencies: `npm install -g bower gulp`
-* Install local dev dependencies: `npm install && bower install` in repository directory
+* Install local dev dependencies: `npm install` in repository directory
 
 ### Development Commands
 


### PR DESCRIPTION
Following merge of #945 bower is not longer required for development, this commit removes it from travis build and dev setup docs.