### PR TITLE
Update common.js

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -139,10 +139,44 @@ var uis = angular.module('ui.select', [])
     return ('' + queryToEscape).replace(/([.?*+^$[\]\\(){}|-])/g, '\\$1');
   }
 
+  function isZeroWidthJoiner(first, second){
+    //Get First Character and match Whitespaces
+    if(second.substr(0,1).match(/\s+/))
+      return false;
+
+    //Get Last Character and Match Persian Letters That Should Use ZWJ
+    return !!first.substr(first.length>0?first.length-1:0).match(/[يئبپتجچحخسشصضطظعغفقکگلمنهی]/);
+  }
+
   return function(matchItem, query) {
-    return query && matchItem ? ('' + matchItem).replace(new RegExp(escapeRegexp(query), 'gi'), '<span class="ui-select-highlight">$&</span>') : matchItem;
+    if(query && matchItem) {
+      var parts = matchItem.split(new RegExp(escapeRegexp(query), 'gi'));
+      var result = "";
+      for (var i = 0; i < parts.length; i++) {
+        if (isZeroWidthJoiner(parts[i], query)) {
+          if(i == parts.length-1)
+            result += parts[i];
+          else if (isZeroWidthJoiner(query, parts[i+1]?parts[i+1]:" "))
+            result += parts[i] + '&zwj;<span class="ui-select-highlight">&zwj;' + query + '&zwj;</span>&zwj;';
+          else
+            result += parts[i] + '&zwj;<span class="ui-select-highlight">&zwj;' + query + '</span>';
+        } else {
+          if(i == parts.length-1)
+            result += parts[i];
+          else if (isZeroWidthJoiner(query, parts[i+1]?parts[i+1]:" "))
+            result += parts[i] + '<span class="ui-select-highlight">' + query + '&zwj;</span>&zwj;';
+          else
+            result += parts[i] + '<span class="ui-select-highlight">' + query + '</span>';
+        }
+      }
+    }else{
+      result = matchItem;
+    }
+    return result;
+    //return query && matchItem ? ('' + matchItem).replace(new RegExp(escapeRegexp(query), 'gi'), '&zwj;<span class="ui-select-highlight">$&</span>&zwj;') : matchItem;
   };
 })
+
 
 /**
  * A read-only equivalent of jQuery's offset function: http://api.jquery.com/offset/

--- a/src/common.js
+++ b/src/common.js
@@ -149,9 +149,10 @@ var uis = angular.module('ui.select', [])
   }
 
   return function(matchItem, query) {
+    var result;
     if(query && matchItem) {
       var parts = matchItem.split(new RegExp(escapeRegexp(query), 'gi'));
-      var result = "";
+      result = "";
       for (var i = 0; i < parts.length; i++) {
         if (isZeroWidthJoiner(parts[i], query)) {
           if(i == parts.length-1)


### PR DESCRIPTION
UI-Select split words in person or Arabic, i fix this (but not optimized or refactored).
I add "Zero Width Joiner" ('&zwj;'), so the word before and after span can join together.

I made a regex which check for Persian character which should join to the next letter. i include Arabic 'ي' and 'ئ' as we use them too.
for other languages, people should add up those characters....
this can also be done using a callback, or filter param, so they can add up their needs, if the highlighter doesn't support specific letter.

The issue caused by highlighter is same to what is described in here, by someone else:
http://stackoverflow.com/questions/7069247/inserting-html-tag-in-the-middle-of-arabic-word-breaks-word-connection-cursive