### PR TITLE
docs(examples) fix double header/footer wrapping

### DIFF
--- a/docs/partials/_header.html
+++ b/docs/partials/_header.html
@@ -1,4 +1,4 @@
-﻿﻿<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en" ng-app="demo">
 <head>
     <meta charset="utf-8">

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -170,9 +170,9 @@ gulp.task('docs:assets', function () {
 
 gulp.task('docs:examples', function () {
   return gulp.src(['docs/examples/*.html'])
-    .pipe($.filenames('exampleFiles'))
     .pipe($.header(fs.readFileSync('docs/partials/_header.html')))
     .pipe($.footer(fs.readFileSync('docs/partials/_footer.html')))
+    .pipe($.filenames('exampleFiles'))
     .pipe(gulp.dest('./docs-built/'));
 });
 


### PR DESCRIPTION
filenames plugin appeared to be causing header and footer additions to be run twice.

Also removes dodgy character at start of header html partial