### PR TITLE
Fix taggingLabel initialization for single mode

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -38,6 +38,7 @@ uis.controller('uiSelectCtrl',
   ctrl.multiple = undefined; // Initialized inside uiSelect directive link function
   ctrl.disableChoiceExpression = undefined; // Initialized inside uiSelectChoices directive link function
   ctrl.tagging = {isActivated: false, fct: undefined};
+  ctrl.taggingLabel = '(new)';
   ctrl.taggingTokens = {isActivated: false, tokens: undefined};
   ctrl.lockChoiceExpression = undefined; // Initialized inside uiSelectMatch directive link function
   ctrl.clickTriggeredSelect = false;


### PR DESCRIPTION
Fix taggingLabel initialization for single mode (when it works)

When taggingLabel is not define in ui-select tag and tagging is active with string (not object), the taggingLabel is undefine and we can see "<value> undefined" in the list.
With this code, taggingLabel is initialized with '(new)' as it could be when taggingLabel tag is present whithout value.