### PR TITLE
Update npm package name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For the roadmap, check [issue #3](https://github.com/angular-ui/ui-select/issues
 
 ### npm
 ```
-$ npm install angular-ui-select
+$ npm install ui-select
 ```
 ### bower
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -149,7 +149,7 @@
 
             <h3>Installation</h3>
             <h4>Install via npm</h4>
-            <pre>$ npm install angular-ui-select</pre>
+            <pre>$ npm install ui-select</pre>
             <h4>Install via bower</h4>
             <pre>$ bower install angular-ui-select</pre>
             <p>


### PR DESCRIPTION
Currently the npm module name in the readme is wrong.
We've run into incompatibility issues because of that. (same error like in #224)
Can somebody also deprecate `angular-ui-select` on npm and point to the new name of the module, please.

This pr fixes #1574
