### PR TITLE
feat(ui-select-choices): expression based minimum-input-length

### DIFF
--- a/src/uiSelectChoicesDirective.js
+++ b/src/uiSelectChoicesDirective.js
@@ -68,7 +68,8 @@ uis.directive('uiSelectChoices',
         scope.$watch('$select.search', function(newValue) {
           if(newValue && !$select.open && $select.multiple) $select.activate(false, true);
           $select.activeIndex = $select.tagging.isActivated ? -1 : 0;
-          if (!attrs.minimumInputLength || $select.search.length >= attrs.minimumInputLength) {
+		  var minimumInputLength = attrs.minimumInputLength ? scope.$eval(attrs.minimumInputLength) : null;
+          if (!minimumInputLength || $select.search.length >= minimumInputLength) {
             $select.refresh(attrs.refresh);
           } else {
             $select.items = [];

--- a/src/uiSelectChoicesDirective.js
+++ b/src/uiSelectChoicesDirective.js
@@ -64,11 +64,12 @@ uis.directive('uiSelectChoices',
         scope.$on('$destroy', function() {
           choices.remove();
         });
+        
+        var minimumInputLength = 0;
 
         scope.$watch('$select.search', function(newValue) {
           if(newValue && !$select.open && $select.multiple) $select.activate(false, true);
           $select.activeIndex = $select.tagging.isActivated ? -1 : 0;
-		  var minimumInputLength = attrs.minimumInputLength ? scope.$eval(attrs.minimumInputLength) : null;
           if (!minimumInputLength || $select.search.length >= minimumInputLength) {
             $select.refresh(attrs.refresh);
           } else {
@@ -76,6 +77,11 @@ uis.directive('uiSelectChoices',
           }
         });
 
+        attrs.$observe('minimumInputLength', function() {
+          // $eval() is needed otherwise we get a string instead of a number
+          minimumInputLength = attrs.minimumInputLength ? scope.$eval(attrs.minimumInputLength) : 0;
+        });
+        
         attrs.$observe('refreshDelay', function() {
           // $eval() is needed otherwise we get a string instead of a number
           var refreshDelay = scope.$eval(attrs.refreshDelay);

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -1498,7 +1498,7 @@ describe('ui-select tests', function() {
 
   });
 
-  it('should call refresh function respecting minimum input length option', function () {
+  it('should call refresh function respecting minimum input length constant option', function () {
 
     var el = compileTemplate(
       '<ui-select ng-model="selection.selected"> \
@@ -1506,6 +1506,38 @@ describe('ui-select tests', function() {
         </ui-select-match> \
         <ui-select-choices repeat="person in people | filter: $select.search" \
           refresh="fetchFromServer($select.search)" refresh-delay="0" minimum-input-length="3"> \
+          <div ng-bind-html="person.name | highlight: $select.search"></div> \
+          <div ng-if="person.name==\'Wladimir\'"> \
+            <span class="only-once">I should appear only once</span>\
+          </div> \
+        </ui-select-choices> \
+      </ui-select>'
+    );
+
+    scope.fetchFromServer = function(){};
+
+    spyOn(scope, 'fetchFromServer');
+
+    el.scope().$select.search = 'r';
+    scope.$digest();
+    $timeout.flush();
+    expect(scope.fetchFromServer).not.toHaveBeenCalledWith('r');
+
+    el.scope().$select.search = 'red';
+    scope.$digest();
+    $timeout.flush();
+    expect(scope.fetchFromServer).toHaveBeenCalledWith('red');
+  });
+  
+
+  it('should call refresh function respecting minimum input length expression option', function () {
+
+    var el = compileTemplate(
+      '<ui-select ng-model="selection.selected"> \
+        <ui-select-match> \
+        </ui-select-match> \
+        <ui-select-choices repeat="person in people | filter: $select.search" \
+          refresh="fetchFromServer($select.search)" refresh-delay="0" minimum-input-length="people.length > 5 ? 3 : 0"> \
           <div ng-bind-html="person.name | highlight: $select.search"></div> \
           <div ng-if="person.name==\'Wladimir\'"> \
             <span class="only-once">I should appear only once</span>\


### PR DESCRIPTION
Allows scope expressions to be used to calculate a minimum-input-length filter for the ui-select-choices directive.

Useful for showing all options when the option list is small, but applying a minimum when the list is large eg:

`minimum-input-length="people.length > 50 ? 3 : 0"`