### PR TITLE
fix(select2): hide dropdown if there are no items to show

### DIFF
--- a/src/select2/select-multiple.tpl.html
+++ b/src/select2/select-multiple.tpl.html
@@ -26,7 +26,7 @@
     </li>
   </ul>
   <div class="ui-select-dropdown select2-drop select2-with-searchbox select2-drop-active"
-       ng-class="{'select2-display-none': !$select.open}">
+       ng-class="{'select2-display-none': !$select.open || $select.items.length === 0}">
     <div class="ui-select-choices"></div>
   </div>
 </div>


### PR DESCRIPTION
this is equivalent to #1588 for bootstrap

the empty dropdown behaviour was especially annoying when using ui-select for tagging without choices.