### PR TITLE
template fix for ui-select-no-choice directive

### DIFF
--- a/src/bootstrap/select-multiple.tpl.html
+++ b/src/bootstrap/select-multiple.tpl.html
@@ -17,4 +17,5 @@
            ondrop="return false;">
   </div>
   <div class="ui-select-choices"></div>
+  <div class="ui-select-no-choice"></div>
 </div>


### PR DESCRIPTION
while using ui-select-no-choice directive it doesn't apply for multiselect mode (bootstrap theme). Appropriate markup was missed for multiselect mode in template for bootstrap theme.

fix for #1614 