### PR TITLE
feat(removeSelected): Implement removeSelected property for multiple selects

### DIFF
--- a/docs/assets/demo.js
+++ b/docs/assets/demo.js
@@ -175,6 +175,7 @@ app.controller('DemoCtrl', function ($scope, $http, $timeout, $interval) {
   vm.multipleDemo.selectedPeople2 = vm.multipleDemo.selectedPeople;
   vm.multipleDemo.selectedPeopleWithGroupBy = [vm.people[8], vm.people[6]];
   vm.multipleDemo.selectedPeopleSimple = ['samantha@email.com','wladimir@email.com'];
+  vm.multipleDemo.removeSelectIsFalse = [vm.people[2], vm.people[0]];
 
   vm.appendToBodyDemo = {
     remainingToggleTime: 0,

--- a/docs/examples/demo-multiple-selection.html
+++ b/docs/examples/demo-multiple-selection.html
@@ -72,4 +72,18 @@ $model = {{ctrl.lastRemoved.model}}
   </ui-select>
   <p>Selected: {{multipleDemo.selectedPeopleWithGroupBy}}</p>
 
+  <hr>
+  <h3>Disabling instead of removing selected items</h3>
+  <ui-select multiple ng-model="ctrl.multipleDemo.removeSelectIsFalse" theme="bootstrap" ng-disabled="ctrl.disabled" close-on-select="false" style="width: 800px;" title="Choose a person" remove-selected="false">
+    <ui-select-match placeholder="Select person...">{{$item.name}} &lt;{{$item.email}}&gt;</ui-select-match>
+    <ui-select-choices repeat="person in ctrl.people | propsFilter: {name: $select.search, age: $select.search}">
+      <div ng-bind-html="person.name | highlight: $select.search"></div>
+      <small>
+        email: {{person.email}}
+        age: <span ng-bind-html="''+person.age | highlight: $select.search"></span>
+      </small>
+    </ui-select-choices>
+  </ui-select>
+  <p>Selected: {{multipleDemo.removeSelectIsFalse}}</p>
+
   <div style="height:500px"></div>

--- a/src/common.js
+++ b/src/common.js
@@ -101,6 +101,7 @@ var uis = angular.module('ui.select', [])
   closeOnSelect: true,
   skipFocusser: false,
   dropdownPosition: 'auto',
+  removeSelected: true,
   generateId: function() {
     return latestId++;
   },

--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -87,6 +87,11 @@ uis.directive('uiSelect',
             $select.sortable = sortable !== undefined ? sortable : uiSelectConfig.sortable;
         });
 
+        scope.$watch('removeSelected', function() {
+            var removeSelected = scope.$eval(attrs.removeSelected);
+            $select.removeSelected = removeSelected !== undefined ? removeSelected : uiSelectConfig.removeSelected;
+        });
+
         attrs.$observe('disabled', function() {
           // No need to use $eval() (thanks to ng-disabled) since we already get a boolean instead of a string
           $select.disabled = attrs.disabled !== undefined ? attrs.disabled : false;

--- a/src/uiSelectMultipleDirective.js
+++ b/src/uiSelectMultipleDirective.js
@@ -76,7 +76,6 @@ uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelec
       //$select.selected = raw selected objects (ignoring any property binding)
 
       $select.multiple = true;
-      $select.removeSelected = true;
 
       //Input that will handle focus
       $select.focusInput = $select.searchInput;

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -1427,6 +1427,56 @@ describe('ui-select tests', function() {
     expect($(el).scope().$select.selected).toEqual(['idontexist']);
   });
 
+  it('should remove a choice when remove-selected is not given (default is true)', function () {
+
+    var el = compileTemplate(
+      '<ui-select multiple ng-model="selection.selected"> \
+        <ui-select-match placeholder="Pick one...">{{$select.selected.name}}</ui-select-match> \
+        <ui-select-choices repeat="person in people | filter: $select.search"> \
+          <div class="person-name" ng-bind-html="person.name" | highlight: $select.search"></div> \
+          <div ng-bind-html="person.email | highlight: $select.search"></div> \
+        </ui-select-choices> \
+      </ui-select>'
+    );
+
+    clickItem(el, 'Samantha');
+    clickItem(el, 'Adrian');
+
+    openDropdown(el);
+
+    var choicesEls = $(el).find('.ui-select-choices-row');
+    expect(choicesEls.length).toEqual(6);
+
+    ['Adam', 'Amalie', 'Estefanía', 'Wladimir', 'Nicole', 'Natasha'].forEach(function (name, index) {
+      expect($(choicesEls[index]).hasClass('disabled')).toBeFalsy();
+      expect($(choicesEls[index]).find('.person-name').text()).toEqual(name);
+    });
+  });
+
+  it('should disable a choice instead of removing it when remove-selected is false', function () {
+
+    var el = compileTemplate(
+      '<ui-select multiple remove-selected="false" ng-model="selection.selected"> \
+        <ui-select-match placeholder="Pick one...">{{$select.selected.name}}</ui-select-match> \
+        <ui-select-choices repeat="person in people | filter: $select.search"> \
+          <div ng-bind-html="person.name" | highlight: $select.search"></div> \
+          <div ng-bind-html="person.email | highlight: $select.search"></div> \
+        </ui-select-choices> \
+      </ui-select>'
+    );
+
+    clickItem(el, 'Samantha');
+    clickItem(el, 'Adrian');
+
+    openDropdown(el);
+
+    var choicesEls = $(el).find('.ui-select-choices-row');
+    expect(choicesEls.length).toEqual(8);
+    [false, false, false, true /* Adrian */, false, true /* Samantha */, false, false].forEach(function (bool, index) {
+      expect($(choicesEls[index]).hasClass('disabled')).toEqual(bool);
+    });
+  });
+
   it('should append/transclude content (with correct scope) that users add at <match> tag', function () {
 
     var el = compileTemplate(


### PR DESCRIPTION
Expose and implement `remove-selected="false"` for multiple selects. This will disable a choice
in the dropdown of a multiple-select element instead of removing it.

Sample behavior:
<img width="239" alt="screen shot 2016-04-18 at 6 07 42 pm" src="https://cloud.githubusercontent.com/assets/382242/14624543/8759f38a-0590-11e6-9a02-a87e15263f44.png">

In the existing version, `id` would not have appeared in the dropdown because it is currently selected. This pull request adds the option `removeSelected` so that, if set to `false`, selected items still appear in the dropdown but are disabled (like in the screenshot).