### PR TITLE
933 Fix text overflow in placeholder and match text

### DIFF
--- a/src/common.css
+++ b/src/common.css
@@ -261,3 +261,12 @@ body > .ui-select-bootstrap.open {
 .ui-select-container[theme="bootstrap"].direction-up .ui-select-dropdown {
     box-shadow: 0 -4px 8px rgba(0, 0, 0, 0.25);
 }
+
+/* fix ellipsis on placeholder and match text */
+.ui-select-placeholder, .ui-select-match-text {
+  width: 100%;
+  overflow: hidden;
+  display: inline-block;
+  text-overflow: ellipsis;
+  padding-right: 40px;
+}


### PR DESCRIPTION
Just added a `display: inline-block` to the @rzschech [solution](https://github.com/angular-ui/ui-select/issues/933#issuecomment-116773277).

Fix #933 