### PR TITLE
fix: search input width resizing

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -471,7 +471,7 @@ uis.controller('uiSelectCtrl',
     ctrl.searchInput.css('width', '10px');
     $timeout(function() { //Give tags time to render correctly
       if (sizeWatch === null && !updateIfVisible(calculateContainerWidth())) {
-        sizeWatch = $scope.$watch(angular.noop, function() {
+        sizeWatch = $scope.$watch(function() {
           if (!updaterScheduled) {
             updaterScheduled = true;
             $scope.$$postDigest(function() {
@@ -482,7 +482,7 @@ uis.controller('uiSelectCtrl',
               }
             });
           }
-        });
+        }, angular.noop);
       }
     });
   };


### PR DESCRIPTION
Fixed an issue introduced by d78ba5f8f6e700143bdf3af1bfda0c05153daf45
The watcher was called only once since `angular.noop` will always return `undefined`.
Fixed this by calling the resize function on each `$digest` cycle.

Closes #1618
Closes #1617
Closes #1575