### PR TITLE
feat(search box): add initSearchValue

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -18,6 +18,7 @@ uis.controller('uiSelectCtrl',
   ctrl.refreshDelay = uiSelectConfig.refreshDelay;
   ctrl.paste = uiSelectConfig.paste;
 
+  ctrl.initSearchValue = EMPTY_SEARCH;
   ctrl.removeSelected = uiSelectConfig.removeSelected; //If selected item(s) should be removed from dropdown list
   ctrl.closeOnSelect = true; //Initialized inside uiSelect directive link function
   ctrl.skipFocusser = false; //Set to true to avoid returning focus to ctrl when item is selected
@@ -109,6 +110,7 @@ uis.controller('uiSelectCtrl',
   // When the user clicks on ui-select, displays the dropdown list
   ctrl.activate = function(initSearchValue, avoidReset) {
     if (!ctrl.disabled  && !ctrl.open) {
+      initSearchValue = initSearchValue !== undefined ? initSearchValue : ctrl.initSearchValue;
       if(!avoidReset) _resetSearchInput();
 
       $scope.$broadcast('uis:activate');

--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -94,6 +94,11 @@ uis.directive('uiSelect',
             $select.removeSelected = removeSelected !== undefined ? removeSelected : uiSelectConfig.removeSelected;
         });
 
+        attrs.$observe('initSearchValue', function() {
+            var initSearchValue = attrs.initSearchValue;
+            $select.initSearchValue = initSearchValue !== undefined ? initSearchValue : '';
+        });
+
         attrs.$observe('disabled', function() {
           // No need to use $eval() (thanks to ng-disabled) since we already get a boolean instead of a string
           $select.disabled = attrs.disabled !== undefined ? attrs.disabled : false;


### PR DESCRIPTION
Set the search box's text to initSearchValue instead of empty string when the dropdown gets toggled.

NOTE: Attempted to write a valid test, but couldn't trigger `activate()` using either `openDropdown()` or `$(el).click()`.

More info in the comment. 

Closes #1645 
