### PR TITLE
Add allow-free-text attribute

### DIFF
--- a/docs/assets/demo.js
+++ b/docs/assets/demo.js
@@ -165,7 +165,8 @@ app.controller('DemoCtrl', function ($scope, $http, $timeout, $interval) {
   ];
 
   vm.availableColors = ['Red','Green','Blue','Yellow','Magenta','Maroon','Umbra','Turquoise'];
-
+  vm.freeTextDemo = {};
+  vm.freeTextDemo.color = '';
   vm.singleDemo = {};
   vm.singleDemo.color = '';
   vm.multipleDemo = {};

--- a/docs/examples/demo-free-text.html
+++ b/docs/examples/demo-free-text.html
@@ -1,0 +1,29 @@
+﻿  <button class="btn btn-default btn-xs" ng-click="ctrl.enable()">Enable ui-select</button>
+  <button class="btn btn-default btn-xs" ng-click="ctrl.disable()">Disable ui-select</button>
+  <button class="btn btn-default btn-xs" ng-click="ctrl.clear()">Clear ng-model</button>
+
+  <h1>Free text</h1>
+  <h3>Regular uiSelect</h3>
+  <p>Without the <code>allow-free-text</code> attribute, it's impossible to enter a non existing item</p>
+  <ui-select ng-model="ctrl.freeTextDemo.color" theme="bootstrap" style="width: 800px;" title="Choose a color">
+    <ui-select-match placeholder="Select color...">{{$select.selected}}</ui-select-match>
+    <ui-select-choices repeat="color in ctrl.availableColors | filter: $select.search">
+      <div ng-bind-html="color | highlight: $select.search"></div>
+    </ui-select-choices>
+  </ui-select>
+  <p>
+  <pre style="width: 800px;">ctrl.freeTextDemo.color = {{ctrl.freeTextDemo.color | json}}</pre>
+  </p>
+
+  <hr>
+  <h3>With free text</h3>
+  <p>Use the <code>allow-free-text</code> attribute to allow non existing item in the box</p>
+  <ui-select allow-free-text="true" ng-model="ctrl.freeTextDemo.color2" theme="bootstrap" style="width: 800px;" title="Choose a color">
+    <ui-select-match placeholder="Select color...">{{$select.selected}}</ui-select-match>
+    <ui-select-choices repeat="color in ctrl.availableColors | filter: $select.search">
+      <div ng-bind-html="color | highlight: $select.search"></div>
+    </ui-select-choices>
+  </ui-select>
+  <p>
+    <pre style="width: 800px;">ctrl.freeTextDemo.color2 = {{ctrl.freeTextDemo.color2 | json}}</pre>
+  </p>

--- a/src/common.js
+++ b/src/common.js
@@ -95,6 +95,7 @@ var uis = angular.module('ui.select', [])
 .constant('uiSelectConfig', {
   theme: 'bootstrap',
   searchEnabled: true,
+  allowFreeText: false,
   sortable: false,
   placeholder: '', // Empty by default, like HTML tag <select>
   refreshDelay: 1000, // In milliseconds

--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -15,6 +15,7 @@ uis.controller('uiSelectCtrl',
   ctrl.placeholder = uiSelectConfig.placeholder;
   ctrl.searchEnabled = uiSelectConfig.searchEnabled;
   ctrl.sortable = uiSelectConfig.sortable;
+  ctrl.allowFreeText = uiSelectConfig.allowFreeText;
   ctrl.refreshDelay = uiSelectConfig.refreshDelay;
   ctrl.paste = uiSelectConfig.paste;
 
@@ -524,6 +525,18 @@ uis.controller('uiSelectCtrl',
     return processed;
   }
 
+  function _handleBlurAndTab() {
+    if (ctrl.allowFreeText && ctrl.search) { // Make sure that the search is not empty, otherwise the blur event will override the tab keydown event
+      ctrl.select(ctrl.search);
+      ctrl.close();
+      ctrl.search = EMPTY_SEARCH;
+    }
+  }
+
+  ctrl.searchInput.on('blur', function() {
+    _handleBlurAndTab();
+  });
+
   // Bind to keyboard shortcuts
   ctrl.searchInput.on('keydown', function(e) {
 
@@ -533,11 +546,6 @@ uis.controller('uiSelectCtrl',
       e.preventDefault();
       e.stopPropagation();
     }
-
-    // if(~[KEY.ESC,KEY.TAB].indexOf(key)){
-    //   //TODO: SEGURO?
-    //   ctrl.close();
-    // }
 
     $scope.$apply(function() {
 
@@ -564,6 +572,14 @@ uis.controller('uiSelectCtrl',
               if (newItem) ctrl.select(newItem, true);
             });
           }
+        }
+      }
+      else if(~[KEY.ESC,KEY.TAB].indexOf(key)){
+        if (!ctrl.allowFreeText) {
+          ctrl.close();
+        }
+        else {
+          _handleBlurAndTab();
         }
       }
 

--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -99,6 +99,11 @@ uis.directive('uiSelect',
           $select.disabled = attrs.disabled !== undefined ? attrs.disabled : false;
         });
 
+        attrs.$observe('allowFreeText', function(allowFreeText) {
+          // No need to use $eval() (thanks to ng-disabled) since we already get a boolean instead of a string
+          $select.allowFreeText = (angular.isDefined(allowFreeText)) ? (allowFreeText === '') ? true : (allowFreeText.toLowerCase() === 'true') : false;
+        });
+
         attrs.$observe('resetSearchInput', function() {
           // $eval() is needed otherwise we get a string instead of a boolean
           var resetSearchInput = scope.$eval(attrs.resetSearchInput);

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -157,6 +157,7 @@ describe('ui-select tests', function() {
       if (attrs.title !== undefined) { attrsHtml += ' title="' + attrs.title + '"'; }
       if (attrs.appendToBody !== undefined) { attrsHtml += ' append-to-body="' + attrs.appendToBody + '"'; }
       if (attrs.allowClear !== undefined) { matchAttrsHtml += ' allow-clear="' + attrs.allowClear + '"';}
+      if (attrs.allowFreeText !== undefined) { attrsHtml += ' allow-free-text="' + attrs.allowFreeText + '"';}
       if (attrs.inputId !== undefined) { attrsHtml += ' input-id="' + attrs.inputId + '"'; }
       if (attrs.ngClass !== undefined) { attrsHtml += ' ng-class="' + attrs.ngClass + '"'; }
     }
@@ -628,6 +629,32 @@ describe('ui-select tests', function() {
     $(el).scope().$select.select("I don't exist");
 
     expect($(el).scope().$select.selected).toEqual("I don't exist");
+  });
+
+  it('should allow free text editing if the attribute says so', function() {
+    var el = createUiSelect({allowFreeText: true});
+    clickMatch(el);
+
+    var searchInput = el.find('.ui-select-search');
+    setSearchText(el, 'someKindOfFreeTextForBlurEvent');
+    searchInput.blur();
+    expect($(el).scope().$select.selected).toEqual('someKindOfFreeTextForBlurEvent');
+
+    clickMatch(el);
+    setSearchText(el, 'someKindOfFreeTextForTabKeydown');
+    triggerKeydown(searchInput, Key.Tab);
+    expect($(el).scope().$select.selected).toEqual('someKindOfFreeTextForTabKeydown');
+  });
+
+  it('should not allow a non existing item on TAB keydown', function() {
+    var el = createUiSelect();
+    clickMatch(el);
+
+    var searchInput = el.find('.ui-select-search');
+    setSearchText(el, 'someKindOfFreeTextForBlurEvent');
+    triggerKeydown(searchInput, Key.Tab);
+
+    expect($(el).scope().$select.selected).not.toBeDefined();
   });
 
   it('should format new items using the tagging function when the attribute is a function', function() {


### PR DESCRIPTION
Fixes the issue #367 

The attribute name allow-free-text almost says it all : it allows the user to enter a non-existing item and keep the value in the model when he presses the TAB key or blur the element by clicking outside it.