### PR TITLE
fix(bootstrap layout): Restrict selected length to ui-select-container

### DIFF
--- a/src/common.css
+++ b/src/common.css
@@ -261,3 +261,19 @@ body > .ui-select-bootstrap.open {
 .ui-select-container[theme="bootstrap"].direction-up .ui-select-dropdown {
     box-shadow: 0 -4px 8px rgba(0, 0, 0, 0.25);
 }
+
+.ui-select-bootstrap .ui-select-match-text {
+    width: 100%;
+    padding-right: 1em;
+}
+.ui-select-bootstrap .ui-select-match-text span {
+    display: inline-block;
+    width: 100%;
+    overflow: hidden;
+}
+.ui-select-bootstrap .ui-select-toggle > a.btn {
+  position: absolute;
+  height: 10px;
+  right: 10px;
+  margin-top: -2px;
+}


### PR DESCRIPTION
In bootstrap theme, if you have a ui-select with a given width and a long selected option it can overflow its box.

Reproduced with most recent versions at https://plnkr.co/edit/eHUcO3gdTY86owCOXL18?p=preview .
angularjs 1.5.7, bootstrap 3.3.6, ui-select 0.18.0
