### PR TITLE
fix(searchEnabled): modify searchEnabled watch to evaluate attrs rath…

### DIFF
--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -74,16 +74,15 @@ uis.directive('uiSelect',
           });
         }
 
-        scope.$watch('searchEnabled', function() {
-            var searchEnabled = scope.$eval(attrs.searchEnabled);
-            $select.searchEnabled = searchEnabled !== undefined ? searchEnabled : uiSelectConfig.searchEnabled;
+        scope.$watch(function () { return scope.$eval(attrs.searchEnabled); }, function(newVal) {
+          $select.searchEnabled = newVal !== undefined ? newVal : uiSelectConfig.searchEnabled;
         });
 
         scope.$watch('sortable', function() {
             var sortable = scope.$eval(attrs.sortable);
             $select.sortable = sortable !== undefined ? sortable : uiSelectConfig.sortable;
         });
-        
+
         attrs.$observe('limit', function() {
           //Limit the number of selections allowed
           $select.limit = (angular.isDefined(attrs.limit)) ? parseInt(attrs.limit, 10) : undefined;


### PR DESCRIPTION
…er than scope property

searchEnabled was not reacting to changes in it's value.  This is because searchEnabled has a scope.$watch on it but searchEnabled was set as a property on $select not the scope and the watch would never fire.  Now the watch evaluates the attrs.searchEnabled for changes and properly reacts to changes in it's value.

Closes #505