### PR TITLE
fix(uiSelectMultiple): ensure first item can selected

### DIFF
--- a/src/uiSelectSingleDirective.js
+++ b/src/uiSelectSingleDirective.js
@@ -64,6 +64,14 @@ uis.directive('uiSelectSingle', ['$timeout','$compile', function($timeout, $comp
         focusser.prop('disabled', true); //Will reactivate it on .close()
       });
 
+      $select.clear = function($event) {
+        $select.selected = undefined;
+        $event.stopPropagation();
+        $timeout(function() {
+          $select.focusser[0].focus();
+        }, 0, false);
+      };
+
       //Idea from: https://github.com/ivaynberg/select2/blob/79b5bf6db918d7560bdd959109b7bcfb47edaf43/select2.js#L1954
       var focusser = angular.element("<input ng-disabled='$select.disabled' class='ui-select-focusser ui-select-offscreen' type='text' id='{{ $select.focusserId }}' aria-label='{{ $select.focusserTitle }}' aria-haspopup='true' role='button' />");
       $compile(focusser)(scope);

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -97,6 +97,10 @@ describe('ui-select tests', function() {
       });
     };
 
+    scope.simple = {
+      colors: ['Red', 'Green', 'Blue', 'Yellow', 'Magenta', 'Maroon', 'Umbra', 'Turquoise'],
+      selected: ['Red']
+    };    
 
     scope.people = [
       { name: 'Adam',      email: 'adam@email.com',      group: 'Foo', age: 12 },
@@ -620,7 +624,7 @@ describe('ui-select tests', function() {
 
     expect($(el).scope().$select.selected).not.toBeDefined();
   });
-
+  
   it('should allow tagging if the attribute says so', function() {
     var el = createUiSelect({tagging: true});
     clickMatch(el);
@@ -1400,6 +1404,43 @@ describe('ui-select tests', function() {
     triggerKeydown(searchInput, Key.Enter);
 
     expect($(el).scope().$select.selected).toEqual('idontexist');
+  });
+
+  it('should allow tagging with simple string and no label if attribute says so', function () {
+
+    var el = compileTemplate(
+      '<ui-select multiple tagging tagging-label="false" ng-model="simple.selected"> \
+        <ui-select-match placeholder="Pick one...">{{$select.selected}}</ui-select-match> \
+        <ui-select-choices repeat="color in simple.color | filter: $select.search"> \
+          <div ng-bind-html="color | highlight: $select.search"></div> \
+        </ui-select-choices> \
+      </ui-select>'
+    );
+
+    clickMatch(el);
+
+    $(el).scope().$select.select("I don't exist");
+
+    expect($(el).scope().$select.selected).toEqual(["Red", "I don't exist"]);
+    expect(scope.simple.selected).toEqual(['Red', "I don't exist"])
+  });
+
+  it('should not prevent selecting the first item when tagging with simple string and no label', function () {
+
+    var el = compileTemplate(
+      '<ui-select multiple tagging tagging-label="false" ng-model="simple.selected"> \
+        <ui-select-match placeholder="Pick one...">{{$item}}</ui-select-match> \
+        <ui-select-choices repeat="color in simple.colors | filter: $select.search"> \
+          <div ng-bind-html="color | highlight: $select.search"></div> \
+        </ui-select-choices> \
+      </ui-select>'
+    );
+
+    // ensure test source array has not changed
+    expect(scope.simple.colors[1]).toBe('Green');    
+    clickItem(el, 'Green');
+        
+    expect(scope.simple.selected).toEqual(['Red', 'Green']);
   });
 
   it('should allow creating tag on ENTER in multiple select mode with tagging enabled, no labels', function() {


### PR DESCRIPTION
Issue caused when using simple string item source and tagging label
set to false, causing confusion in selection code between a new tag
and an existing item.

This refactors the selection logic to simplify the code paths and
hopefully make it less prone to errors.

Possible fix for #1214 