### PR TITLE
feat(groupBy): Define group by expression in repeat

### DIFF
--- a/docs/assets/demo.js
+++ b/docs/assets/demo.js
@@ -39,7 +39,13 @@ app.filter('propsFilter', function() {
     return out;
   };
 });
+app.filter('reverseOrderFilterFn', function() {
+  return function(items) {
+    if(!angular.isArray(items)) return items;
 
+    return items.slice().reverse();
+  };
+});
 app.controller('DemoCtrl', function ($scope, $http, $timeout, $interval) {
   var vm = this;
 
@@ -84,10 +90,6 @@ app.controller('DemoCtrl', function ($scope, $http, $timeout, $interval) {
 
   vm.firstLetterGroupFn = function (item){
       return item.name[0];
-  };
-
-  vm.reverseOrderFilterFn = function(groups) {
-    return groups.reverse();
   };
 
   vm.personAsync = {selected : "wladimir@email.com"};

--- a/docs/examples/demo-bootstrap.html
+++ b/docs/examples/demo-bootstrap.html
@@ -25,7 +25,7 @@
 
           <ui-select ng-model="ctrl.person.selected" theme="bootstrap">
             <ui-select-match placeholder="Select or search a person in the list...">{{$select.selected.name}}</ui-select-match>
-            <ui-select-choices group-by="'country'" repeat="item in ctrl.people | filter: $select.search">
+            <ui-select-choices repeat="item in ctrl.people | filter: $select.search group by item.country">
               <span ng-bind-html="item.name | highlight: $select.search"></span>
               <small ng-bind-html="item.email | highlight: $select.search"></small>
             </ui-select-choices>

--- a/docs/examples/demo-group-by.html
+++ b/docs/examples/demo-group-by.html
@@ -5,10 +5,10 @@
   <h1>Group By</h1>
   <p>Selected: {{ctrl.person.selected}}</p>
 
-  <h3>Grouped using a string <small><code>group-by="'country'"</code></small></h3>
+  <h3>Grouped using a string <small><code>"group by person.country"</code></small></h3>
   <ui-select ng-model="ctrl.person.selected" theme="select2" ng-disabled="ctrl.disabled" style="min-width: 300px;" title="Choose a person">
     <ui-select-match placeholder="Select a person in the list or search his name/age...">{{$select.selected.name}}</ui-select-match>
-    <ui-select-choices group-by="'country'" repeat="person in ctrl.people | propsFilter: {name: $select.search, age: $select.search}">
+    <ui-select-choices repeat="person in ctrl.people | propsFilter: {name: $select.search, age: $select.search} group by person.country">
       <div ng-bind-html="person.name | highlight: $select.search"></div>
       <small>
         email: {{person.email}}
@@ -17,17 +17,17 @@
     </ui-select-choices>
     </ui-select>
 
-  <h3>Grouped using a function <small><code>group-by="ctrl.someGroupFn"</code></small></h3>
+  <h3>Grouped using a function <small><code>"group by ctrl.someGroupFn(person)"</code></small></h3>
   <ui-select ng-model="ctrl.person.selected" theme="select2" ng-disabled="ctrl.disabled" style="min-width: 300px;" title="Choose a person">
     <ui-select-match placeholder="Select a person in the list or search his name/age...">{{$select.selected.name}}</ui-select-match>
-    <ui-select-choices group-by="ctrl.someGroupFn" repeat="person in ctrl.people | propsFilter: {name: $select.search, age: $select.search}">
+    <ui-select-choices repeat="person in ctrl.people | propsFilter: {name: $select.search, age: $select.search} group by ctrl.someGroupFn(person)">
       <div ng-bind-html="person.name | highlight: $select.search"></div>
       <small>
         email: {{person.email}}
         age: <span ng-bind-html="''+person.age | highlight: $select.search"></span>
       </small>
     </ui-select-choices>
-    </ui-select>
+  </ui-select>
 
   <h3>Regular</h3>
   <ui-select ng-model="ctrl.person.selected" theme="select2" ng-disabled="ctrl.disabled" style="min-width: 300px;" title="Choose a person">

--- a/docs/examples/demo-group-filter.html
+++ b/docs/examples/demo-group-filter.html
@@ -7,19 +7,37 @@
   <p>Selected: {{country.selected}}</p>
 
 
-  <h3> Filter groups by array <small><code>group-filter="['Z','B','C']"</code></small></h3>
+  <h3> Filter groups by name <small><code>group by ctrl.firstLetterGroupFn(country) | filter:{name: 'Z'}</code></small></h3>
   <ui-select ng-model="ctrl.country.selected" theme="select2" ng-disabled="ctrl.disabled" style="width: 300px;" title="Choose a country">
     <ui-select-match placeholder="Select or search a country in the list...">{{$select.selected.name}}</ui-select-match>
-    <ui-select-choices group-by="ctrl.firstLetterGroupFn" group-filter="['Z','B','C']" repeat="country in ctrl.countries | filter: $select.search">
+    <ui-select-choices repeat="country in ctrl.countries | filter: $select.search group by ctrl.firstLetterGroupFn(country) | filter:{name: 'Z'}">
       <span ng-bind-html="country.name | highlight: $select.search"></span>
       <small ng-bind-html="country.code | highlight: $select.search"></small>
     </ui-select-choices>
   </ui-select>
 
-  <h3>Filter groups using a function <small><code>group-filter="reverseOrderFilterFn"</code></small></h3>
+  <h3> Filter groups by string <small><code>group by ctrl.firstLetterGroupFn(country) | uisGroupFilter:'Z'</code></small></h3>
   <ui-select ng-model="ctrl.country.selected" theme="select2" ng-disabled="ctrl.disabled" style="width: 300px;" title="Choose a country">
     <ui-select-match placeholder="Select or search a country in the list...">{{$select.selected.name}}</ui-select-match>
-    <ui-select-choices group-by="ctrl.firstLetterGroupFn" group-filter="reverseOrderFilterFn" repeat="country in ctrl.countries | filter: $select.search">
+    <ui-select-choices repeat="country in ctrl.countries | filter: $select.search group by ctrl.firstLetterGroupFn(country) | uisGroupFilter:'Z'">
+      <span ng-bind-html="country.name | highlight: $select.search"></span>
+      <small ng-bind-html="country.code | highlight: $select.search"></small>
+    </ui-select-choices>
+  </ui-select>
+
+  <h3> Filter groups by array <small><code>group by ctrl.firstLetterGroupFn(country) | uisGroupFilter:['A', 'B', 'C']</code></small></h3>
+  <ui-select ng-model="ctrl.country.selected" theme="select2" ng-disabled="ctrl.disabled" style="width: 300px;" title="Choose a country">
+    <ui-select-match placeholder="Select or search a country in the list...">{{$select.selected.name}}</ui-select-match>
+    <ui-select-choices repeat="country in ctrl.countries | filter: $select.search group by ctrl.firstLetterGroupFn(country) | uisGroupFilter:['A', 'B', 'C']">
+      <span ng-bind-html="country.name | highlight: $select.search"></span>
+      <small ng-bind-html="country.code | highlight: $select.search"></small>
+    </ui-select-choices>
+  </ui-select>
+
+  <h3>Filter groups using a function <small><code>group by ctrl.firstLetterGroupFn(country) | reverseOrderFilterFn</code></small></h3>
+  <ui-select ng-model="ctrl.country.selected" theme="select2" ng-disabled="ctrl.disabled" style="width: 300px;" title="Choose a country">
+    <ui-select-match placeholder="Select or search a country in the list...">{{$select.selected.name}}</ui-select-match>
+    <ui-select-choices repeat="country in ctrl.countries | filter: $select.search  group by ctrl.firstLetterGroupFn(country) | reverseOrderFilterFn">
       <span ng-bind-html="country.name | highlight: $select.search"></span>
       <small ng-bind-html="country.code | highlight: $select.search"></small>
     </ui-select-choices>

--- a/docs/examples/demo-multiple-selection.html
+++ b/docs/examples/demo-multiple-selection.html
@@ -62,7 +62,7 @@ $model = {{ctrl.lastRemoved.model}}
   <h3>Array of objects (with groupBy)</h3>
   <ui-select multiple ng-model="ctrl.multipleDemo.selectedPeopleWithGroupBy" theme="bootstrap" ng-disabled="ctrl.disabled" close-on-select="false" style="width: 800px;" title="Choose a person">
     <ui-select-match placeholder="Select person...">{{$item.name}} &lt;{{$item.email}}&gt;</ui-select-match>
-    <ui-select-choices group-by="someGroupFn" repeat="person in ctrl.people | propsFilter: {name: $select.search, age: $select.search}">
+    <ui-select-choices repeat="person in ctrl.people | propsFilter: {name: $select.search, age: $select.search} group by someGroupFn(person)">
       <div ng-bind-html="person.name | highlight: $select.search"></div>
       <small>
         email: {{person.email}}

--- a/docs/examples/demo-select2-with-bootstrap.html
+++ b/docs/examples/demo-select2-with-bootstrap.html
@@ -40,7 +40,7 @@
 
           <ui-select ng-model="ctrl.person.selected" theme="select2" class="form-control" title="Choose a person">
             <ui-select-match placeholder="Select or search a person in the list...">{{$select.selected.name}}</ui-select-match>
-            <ui-select-choices group-by="'group'" repeat="item in ctrl.people | filter: $select.search">
+            <ui-select-choices repeat="item in ctrl.people | filter: $select.search group by item.group">
               <span ng-bind-html="item.name | highlight: $select.search"></span>
               <small ng-bind-html="item.email | highlight: $select.search"></small>
             </ui-select-choices>

--- a/docs/examples/demo-selectize-with-bootstrap.html
+++ b/docs/examples/demo-selectize-with-bootstrap.html
@@ -45,7 +45,7 @@
 
           <ui-select ng-model="ctrl.person.selected" theme="selectize" title="Choose a person">
             <ui-select-match placeholder="Select or search a person in the list...">{{$select.selected.name}}</ui-select-match>
-            <ui-select-choices group-by="'group'" repeat="item in ctrl.people | filter: $select.search">
+            <ui-select-choices repeat="item in ctrl.people | filter: $select.search group by item.group">
               <span ng-bind-html="item.name | highlight: $select.search"></span>
               <small ng-bind-html="item.email | highlight: $select.search"></small>
             </ui-select-choices>

--- a/docs/examples/demo-tagging.html
+++ b/docs/examples/demo-tagging.html
@@ -31,7 +31,7 @@
   <h3>Object Tags <small>(with grouping)</small></h3>
   <ui-select multiple tagging="ctrl.tagTransform" ng-model="ctrl.multipleDemo.selectedPeople" theme="bootstrap" ng-disabled="ctrl.disabled" style="width: 800px;" title="Choose a person">
     <ui-select-match placeholder="Select person...">{{$item.name}} &lt;{{$item.email}}&gt;</ui-select-match>
-    <ui-select-choices repeat="person in ctrl.people | propsFilter: {name: $select.search, age: $select.search}" group-by="'country'">
+    <ui-select-choices repeat="person in ctrl.people | propsFilter: {name: $select.search, age: $select.search} group by person.country">
       <div ng-if="person.isTag" ng-bind-html="(person.name | highlight: $select.search) +' (new)'"></div>
       <div ng-if="!person.isTag" ng-bind-html="person.name + person.isTag| highlight: $select.search"></div>
       <small>

--- a/src/common.js
+++ b/src/common.js
@@ -128,7 +128,26 @@ var uis = angular.module('ui.select', [])
       }
     };
 })
+.filter('uisGroupFilter', ['$filter', function($filter) {
+  return function(groups, definition) {
 
+    if(!angular.isArray(groups)) return groups;
+
+    var filterDefintion = [];
+
+    if(angular.isString(definition)) { 
+      filterDefintion = [definition];
+    } else if(angular.isArray(definition)) {
+      filterDefintion = definition;
+    }
+
+    if(filterDefintion.length === 0) return groups;
+
+    return $filter('filter')(groups, function(group) {
+      return filterDefintion.indexOf(group.name) > -1;
+    });
+  };
+}])
 /**
  * Highlights text that matches $select.search.
  *

--- a/src/uiSelectChoicesDirective.js
+++ b/src/uiSelectChoicesDirective.js
@@ -21,23 +21,20 @@ uis.directive('uiSelectChoices',
       if (!tAttrs.repeat) throw uiSelectMinErr('repeat', "Expected 'repeat' expression.");
 
       // var repeat = RepeatParser.parse(attrs.repeat);
-      var groupByExp = tAttrs.groupBy;
-      var groupFilterExp = tAttrs.groupFilter;
+      var parserResult = RepeatParser.parse(tAttrs.repeat);
 
-      if (groupByExp) {
+      if (parserResult.groupByExp) {
         var groups = tElement.querySelectorAll('.ui-select-choices-group');
         if (groups.length !== 1) throw uiSelectMinErr('rows', "Expected 1 .ui-select-choices-group but got '{0}'.", groups.length);
-        groups.attr('ng-repeat', RepeatParser.getGroupNgRepeatExpression());
+        groups.attr('ng-repeat', '$group in $select.groups ' + ( parserResult.groupByFilter || ''));
       }
-
-      var parserResult = RepeatParser.parse(tAttrs.repeat);
 
       var choices = tElement.querySelectorAll('.ui-select-choices-row');
       if (choices.length !== 1) {
         throw uiSelectMinErr('rows', "Expected 1 .ui-select-choices-row but got '{0}'.", choices.length);
       }
 
-      choices.attr('ng-repeat', parserResult.repeatExpression(groupByExp))
+      choices.attr('ng-repeat', parserResult.repeatExpression(parserResult.groupByExp))
              .attr('ng-if', '$select.open'); //Prevent unnecessary watches when dropdown is closed
     
 
@@ -54,7 +51,7 @@ uis.directive('uiSelectChoices',
       return function link(scope, element, attrs, $select) {
 
        
-        $select.parseRepeatAttr(attrs.repeat, groupByExp, groupFilterExp); //Result ready at $select.parserResult
+        $select.parseRepeatAttr(attrs.repeat); //Result ready at $select.parserResult
 
         $select.disableChoiceExpression = attrs.uiDisableChoice;
         $select.onHighlightCallback = attrs.onHighlight;


### PR DESCRIPTION
Changes the method for defining group by to simplify the codebase,
improve performance and better support changes going forward.

BREAKING CHANGE:

Removes support for group-by and group-filter attributes. Instead you
should now use an `ng-repeat` *like* syntax: `... group by x | ...`

For example:
```
<ui-select-choices group-by="'country'" group-filter="['USA']"
  repeat="person in ctrl.people">
```
Now becomes:
```
<ui-select-choices
  repeat="person in ctrl.people group by person.country | filter:{name: 'USA'}">
```
Note that in order support filter groups based on an array with more
than one value (eg.`group-filter="['A', 'B'...]"`) you will need to
use the new `uisGroupFilter` filter.

Example:
```
<ui-select-choices
  repeat="person in ctrl.people group by person.country | uisGroupFilter:['USA','Canada']">
```