### PR TITLE
fix(selectize): show placeholder when search disabled

### DIFF
--- a/src/selectize/match.tpl.html
+++ b/src/selectize/match.tpl.html
@@ -1,1 +1,1 @@
-<div ng-hide="$select.searchEnabled && ($select.open || $select.isEmpty())" class="ui-select-match" ng-transclude></div>
+<div ng-hide="$select.open || $select.isEmpty()" class="ui-select-match" ng-transclude></div>

--- a/src/selectize/select.tpl.html
+++ b/src/selectize/select.tpl.html
@@ -8,8 +8,8 @@
            ng-click="$select.toggle($event)"
            placeholder="{{$select.placeholder}}"
            ng-model="$select.search"
-           ng-hide="!$select.searchEnabled || (!$select.isEmpty() && !$select.open)"
-           ng-disabled="$select.disabled"
+           ng-hide="(!$select.isEmpty() && !$select.open)"
+           ng-disabled="!$select.searchEnabled || $select.disabled"
            aria-label="{{ $select.baseTitle }}">
   </div>
   <div class="ui-select-choices"></div>

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -1698,12 +1698,12 @@ describe('ui-select tests', function() {
 
       it('should show search input when true', function() {
         setupSelectComponent(true, 'selectize');
-        expect($(el).find('.ui-select-search')).not.toHaveClass('ng-hide');
+        expect($(el).find('.ui-select-search').is(':disabled')).toBe(false);
       });
 
       it('should hide search input when false', function() {
         setupSelectComponent(false, 'selectize');
-        expect($(el).find('.ui-select-search')).toHaveClass('ng-hide');
+        expect($(el).find('.ui-select-search').is(':disabled')).toBe(true);
       });
 
     });


### PR DESCRIPTION
Previously when searchEnabled was set to false, the placeholder would
also be hidden on the selectize theme.

This fix sets the search input to disabled rather then hidden when the
searchEnabled attribute is set to false.

Fixes #949 and #691