### PR TITLE
Track groups by their name - Fix issue #1721

### DIFF
--- a/src/uisRepeatParserService.js
+++ b/src/uisRepeatParserService.js
@@ -77,7 +77,7 @@ uis.service('uisRepeatParser', ['uiSelectMinErr','$parse', function(uiSelectMinE
   };
 
   self.getGroupNgRepeatExpression = function() {
-    return '$group in $select.groups';
+    return '$group in $select.groups track by $group.name';
   };
 
 }]);


### PR DESCRIPTION
By using "track by", existing items don't have to be re-rendered when the array changes.