### PR TITLE
fix(uiSelectController): Select by click on non-multiple tagging (bis)

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -340,7 +340,7 @@ uis.controller('uiSelectCtrl',
   function _isItemDisabled(item) {
     return disabledItems.indexOf(item) > -1;
   }
-  
+
   ctrl.isDisabled = function(itemScope) {
 
     if (!ctrl.open) return;
@@ -348,7 +348,7 @@ uis.controller('uiSelectCtrl',
     var item = itemScope[ctrl.itemProperty];
     var itemIndex = ctrl.items.indexOf(item);
     var isDisabled = false;
-    
+
     if (itemIndex >= 0 && (angular.isDefined(ctrl.disableChoiceExpression) || ctrl.multiple)) {
 
       if (item.isTag) return false;
@@ -360,7 +360,7 @@ uis.controller('uiSelectCtrl',
       if (!isDisabled && angular.isDefined(ctrl.disableChoiceExpression)) {
         isDisabled = !!(itemScope.$eval(ctrl.disableChoiceExpression));
       }
-      
+
       _updateItemDisabled(item, isDisabled);
     }
 
@@ -375,7 +375,11 @@ uis.controller('uiSelectCtrl',
       if ( ! ctrl.items && ! ctrl.search && ! ctrl.tagging.isActivated) return;
 
       if (!item || !_isItemDisabled(item)) {
-        if(ctrl.tagging.isActivated) {
+        // if click is made on existing item, prevent from tagging, ctrl.search does not matter
+        var manualSelection = false;
+        if($event && $event.type === 'click' && item)
+          manualSelection = true;
+        if(ctrl.tagging.isActivated && manualSelection === false) {
           // if taggingLabel is disabled and item is undefined we pull from ctrl.search
           if ( ctrl.taggingLabel === false ) {
             if ( ctrl.activeIndex < 0 ) {
@@ -472,7 +476,7 @@ uis.controller('uiSelectCtrl',
     }
   };
 
-  // Set default function for locked choices - avoids unnecessary 
+  // Set default function for locked choices - avoids unnecessary
   // logic if functionality is not being used
   ctrl.isLocked = function () {
     return false;
@@ -484,7 +488,7 @@ uis.controller('uiSelectCtrl',
 
   function _initaliseLockedChoices(doInitalise) {
     if(!doInitalise) return;
-    
+
     var lockedItems = [];
 
     function _updateItemLocked(item, isLocked) {
@@ -518,7 +522,7 @@ uis.controller('uiSelectCtrl',
       return isLocked;
     };
   }
-  
+
 
   var sizeWatch = null;
   var updaterScheduled = false;

--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -376,10 +376,11 @@ uis.controller('uiSelectCtrl',
 
       if (!item || !_isItemDisabled(item)) {
         // if click is made on existing item, prevent from tagging, ctrl.search does not matter
-        var manualSelection = false;
+        ctrl.clickTriggeredSelect = false;
         if($event && $event.type === 'click' && item)
-          manualSelection = true;
-        if(ctrl.tagging.isActivated && manualSelection === false) {
+          ctrl.clickTriggeredSelect = true;
+
+        if(ctrl.tagging.isActivated && ctrl.clickTriggeredSelect === false) {
           // if taggingLabel is disabled and item is undefined we pull from ctrl.search
           if ( ctrl.taggingLabel === false ) {
             if ( ctrl.activeIndex < 0 ) {
@@ -434,9 +435,6 @@ uis.controller('uiSelectCtrl',
 
         if (ctrl.closeOnSelect) {
           ctrl.close(skipFocusser);
-        }
-        if ($event && $event.type === 'click') {
-          ctrl.clickTriggeredSelect = true;
         }
       }
     }

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -1427,6 +1427,31 @@ describe('ui-select tests', function() {
     expect($(el).scope().$select.selected).toEqual(['idontexist']);
   });
 
+  it('should allow selecting an item (click) in single select mode with tagging enabled', function() {
+
+    scope.taggingFunc = function (name) {
+      return name;
+    };
+
+    var el = compileTemplate(
+      '<ui-select ng-model="selection.selected" tagging="taggingFunc" tagging-label="false"> \
+        <ui-select-match placeholder="Pick one...">{{$select.selected.name}}</ui-select-match> \
+        <ui-select-choices repeat="person in people | filter: $select.search"> \
+          <div ng-bind-html="person.name" | highlight: $select.search"></div> \
+          <div ng-bind-html="person.email | highlight: $select.search"></div> \
+        </ui-select-choices> \
+      </ui-select>'
+    );
+
+    clickMatch(el);
+    setSearchText(el, 'Sam');
+    clickItem(el, 'Samantha');
+
+    expect(scope.selection.selected).toBe(scope.people[5]);
+    expect(getMatchLabel(el)).toEqual('Samantha');
+  });
+
+
   it('should remove a choice when multiple and remove-selected is not given (default is true)', function () {
 
     var el = compileTemplate(
@@ -2527,7 +2552,7 @@ describe('ui-select tests', function() {
       expect(el.scope().$select.items[1]).toEqual(jasmine.objectContaining({name: 'Amalie', email: 'amalie@email.com'}));
     });
 
-    
+
     it('should have tolerance for undefined values', function () {
 
       scope.modelValue = undefined;
@@ -2563,7 +2588,7 @@ describe('ui-select tests', function() {
 
       expect($(el).scope().$select.selected).toEqual([]);
     });
-      
+
     it('should allow paste tag from clipboard', function() {
       scope.taggingFunc = function (name) {
         return {


### PR DESCRIPTION
When in tagging mode, not multiple (taggingLabel === false), selecting an item by click was instead calling taggingFunc(). This fix checks
for this manual selection, whether ctrl.search is filled or not and
acts accordingly.
Same changes made in #1439 that were mysteriously lost.

Closes #1496 