### PR TITLE
change tabindex and add custom validation

### DIFF
--- a/src/bootstrap/match.tpl.html
+++ b/src/bootstrap/match.tpl.html
@@ -1,6 +1,5 @@
 <div class="ui-select-match" ng-hide="$select.open && $select.searchEnabled" ng-disabled="$select.disabled" ng-class="{'btn-default-focus':$select.focus}">
-  <span tabindex="-1"
-      class="btn btn-default form-control ui-select-toggle"
+  <span class="btn btn-default form-control ui-select-toggle"
       aria-label="{{ $select.baseTitle }} activate"
       ng-disabled="$select.disabled" 
       ng-click="$select.activate()"

--- a/src/bootstrap/select.tpl.html
+++ b/src/bootstrap/select.tpl.html
@@ -1,6 +1,6 @@
 <div class="ui-select-container ui-select-bootstrap dropdown" ng-class="{open: $select.open}">
   <div class="ui-select-match"></div>
-  <input type="search" autocomplete="off" tabindex="-1"
+  <input type="search" autocomplete="off"
          aria-expanded="true"
          aria-label="{{ $select.baseTitle }}"
          aria-owns="ui-select-choices-{{ $select.generatedId }}"

--- a/src/bootstrap/select.tpl.html
+++ b/src/bootstrap/select.tpl.html
@@ -8,7 +8,8 @@
          class="form-control ui-select-search"
          placeholder="{{$select.placeholder}}"
          ng-model="$select.search"
-         ng-show="$select.searchEnabled && $select.open">
+         ng-show="$select.searchEnabled && $select.open"
+         ng-blur="$select.inputBlur()">
   <div class="ui-select-choices"></div>
   <div class="ui-select-no-choice"></div>
 </div>

--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -43,6 +43,8 @@ uis.controller('uiSelectCtrl',
   ctrl.clickTriggeredSelect = false;
   ctrl.$filter = $filter;
   ctrl.$element = $element;
+  ctrl.customValidation = undefined;
+  ctrl.inputBlur = function () { if (ctrl.customValidation) $scope.$eval(ctrl.customValidation) };
 
   // Use $injector to check for $animate and store a reference to it
   ctrl.$animate = (function () {

--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -44,7 +44,7 @@ uis.controller('uiSelectCtrl',
   ctrl.$filter = $filter;
   ctrl.$element = $element;
   ctrl.customValidation = undefined;
-  ctrl.inputBlur = function () { if (ctrl.customValidation) $scope.$eval(ctrl.customValidation) };
+  ctrl.inputBlur = function () { if (ctrl.customValidation) $scope.$eval(ctrl.customValidation); };
 
   // Use $injector to check for $animate and store a reference to it
   ctrl.$animate = (function () {

--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -76,6 +76,10 @@ uis.directive('uiSelect',
           });
         }
 
+        attrs.$observe('validation', function () {
+          $select.customValidation = attrs.validation;
+        });
+
         scope.$watch(function () { return scope.$eval(attrs.searchEnabled); }, function(newVal) {
           $select.searchEnabled = newVal !== undefined ? newVal : uiSelectConfig.searchEnabled;
         });

--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -69,7 +69,9 @@ uis.directive('uiSelect',
 
         if(attrs.tabindex){
           attrs.$observe('tabindex', function(value) {
+            $select.tabindex = value;
             $select.focusInput.attr('tabindex', value);
+            $select.searchInput.attr('tabindex', value);
             element.removeAttr('tabindex');
           });
         }


### PR DESCRIPTION
Changed the tabindex behavior, so that it is possible to set the tabindex of the input field. Before it was not possible to tab into the input field and type.

Added a property, that allows to set a custom validation method, which is executed on blur. Works when selecting a value by mouse (click), enter or when tabbing out of the input field. Can be used as a workaround for ng-blur.