### PR TITLE
Fix: issue #877 Typing fast in firefox skips the second character 

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -111,8 +111,6 @@ uis.controller('uiSelectCtrl',
     if (!ctrl.disabled  && !ctrl.open) {
       if(!avoidReset) _resetSearchInput();
 
-      $scope.$broadcast('uis:activate');
-
       ctrl.open = true;
 
       ctrl.activeIndex = ctrl.activeIndex >= ctrl.items.length ? 0 : ctrl.activeIndex;
@@ -163,8 +161,12 @@ uis.controller('uiSelectCtrl',
   };
 
   ctrl.focusSearchInput = function (initSearchValue) {
-    ctrl.search = initSearchValue || ctrl.search;
+    if (initSearchValue) {
+      ctrl.search = initSearchValue.val() || ctrl.search;
+      initSearchValue.val('');
+    }
     ctrl.searchInput[0].focus();
+    $scope.$broadcast('uis:activate');
   };
 
   ctrl.findGroupByName = function(name) {
@@ -423,7 +425,7 @@ uis.controller('uiSelectCtrl',
             ctrl.close(skipFocusser);
             return;
           }
-        }        
+        }
         _resetSearchInput();
         $scope.$broadcast('uis:select', item);
 

--- a/src/uiSelectSingleDirective.js
+++ b/src/uiSelectSingleDirective.js
@@ -112,8 +112,7 @@ uis.directive('uiSelectSingle', ['$timeout','$compile', function($timeout, $comp
           return;
         }
 
-        $select.activate(focusser.val()); //User pressed some regular key, so we pass it to the search input
-        focusser.val('');
+        $select.activate(focusser); //User pressed some regular key, so we pass it to the search input
         scope.$digest();
 
       });


### PR DESCRIPTION
Changing the focus on elements does not always go fast enough in firefox to reliably catch all keystrokes. This fix changes the order of events, and keeps catching keystrokes after the first until the focus has shifted.

(I messed up the original pull request #896) Also see #877