### PR TITLE
Set clickTriggeredSelect to true for touchend events

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -381,7 +381,7 @@ uis.controller('uiSelectCtrl',
       if (!item || !_isItemDisabled(item)) {
         // if click is made on existing item, prevent from tagging, ctrl.search does not matter
         ctrl.clickTriggeredSelect = false;
-        if($event && $event.type === 'click' && item)
+        if($event && ($event.type === 'click' || $event.type === 'touchend') && item)
           ctrl.clickTriggeredSelect = true;
 
         if(ctrl.tagging.isActivated && ctrl.clickTriggeredSelect === false) {


### PR DESCRIPTION
Setting clickTriggeredSelect to true for "touchend" events fixes an issue I've encoutered when using this property in a search box (using ui-select-match and ui-select-choices), where we couldn't distinguish typing from clicking on an autocomplete result on mobile devices.