### PR TITLE
fix(_updateItemLocked) properly unlock locked items when lock conditions change

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -423,7 +423,7 @@ uis.controller('uiSelectCtrl',
             ctrl.close(skipFocusser);
             return;
           }
-        }        
+        }
         _resetSearchInput();
         $scope.$broadcast('uis:select', item);
 
@@ -499,7 +499,7 @@ uis.controller('uiSelectCtrl',
         }
 
       if (!isLocked && lockedItemIndex > -1) {
-        lockedItems.splice(lockedItemIndex, 0);
+        lockedItems.splice(lockedItemIndex, 1);
       }
     }
 


### PR DESCRIPTION
Previously when the lock expression value changes from true to false the locked value was not removed from the locked list.