### PR TITLE
fix(uiSelectChoices): prevent template element from being modified

### DIFF
--- a/src/uiSelectChoicesDirective.js
+++ b/src/uiSelectChoicesDirective.js
@@ -61,10 +61,6 @@ uis.directive('uiSelectChoices',
 
         $select.dropdownPosition = attrs.position ? attrs.position.toLowerCase() : uiSelectConfig.dropdownPosition;        
 
-        scope.$on('$destroy', function() {
-          choices.remove();
-        });
-
         scope.$watch('$select.search', function(newValue) {
           if(newValue && !$select.open && $select.multiple) $select.activate(false, true);
           $select.activeIndex = $select.tagging.isActivated ? -1 : 0;

--- a/src/uiSelectChoicesDirective.js
+++ b/src/uiSelectChoicesDirective.js
@@ -79,9 +79,9 @@ uis.directive('uiSelectChoices',
 
         scope.$watch('$select.open', function(open) {
           if (open) {
-            tElement.attr('role', 'listbox');
+            element.attr('role', 'listbox');
           } else {
-            tElement.removeAttr('role');
+            element.removeAttr('role');
           }
         });
       };


### PR DESCRIPTION
Previously, the .ui-select-choices-row element got deleted whenever the linked scope got destroyed which prevents rendering of the options in some cases.