### PR TITLE
Allow manually send event for update element width (close #1666)

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -739,6 +739,8 @@ uis.controller('uiSelectCtrl',
     angular.element($window).off('resize', onResize);
   });
 
+  $scope.$on('updateUISelectSize', ctrl.sizeSearchInput);
+
   $scope.$watch('$select.activeIndex', function(activeIndex) {
     if (activeIndex)
       $element.find('input').attr(


### PR DESCRIPTION
This is workaround to fix placeholder width=10px if ui-select was not visible when created. It is possible now fix this by sending special event: $broadcast('updateUISelectSize').