### PR TITLE
Change $select.clear() so it sets value to `null` instead of `undefined`

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -451,7 +451,7 @@ uis.controller('uiSelectCtrl',
   };
 
   ctrl.clear = function($event) {
-    ctrl.select(undefined);
+    ctrl.select(null);
     $event.stopPropagation();
     $timeout(function() {
       ctrl.focusser[0].focus();

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -552,7 +552,7 @@ describe('ui-select tests', function() {
 
     // Trigger clear.
     el.find('.select2-search-choice-close').click();
-    expect(scope.selection.selected).toEqual(undefined);
+    expect(scope.selection.selected).toEqual(null);
 
     // If there is no selection it the X icon should be gone.
     expect(el.find('.select2-search-choice-close').length).toEqual(0);


### PR DESCRIPTION
Type: fix
Scope: uiSelectMatch

Fixes https://github.com/angular-ui/ui-select/issues/863