### PR TITLE
Remove tagging label when clicked in dropdown

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -425,6 +425,8 @@ uis.controller('uiSelectCtrl',
             ctrl.close(skipFocusser);
             return;
           }
+        } else if ( typeof item === 'string') {
+          item = item.replace(ctrl.taggingLabel,'').trim();
         }
         _resetSearchInput();
         $scope.$broadcast('uis:select', item);


### PR DESCRIPTION
This fixes #1806.  

This bug was introduced from PR #1727.

Here is a plunker to represent the issue: http://plnkr.co/edit/zv41jdiLa2eylIdM9tu8. When you type in a field and click on it (don't press enter), the tagging label gets included in the tag.

This fix adds a tiny bit of duplicate code from line 417-ish of the same file, but this particular area of code seems potentially fragile, so I opted minimal changes.  Ideally this whole lot of code needs to change to improve the way this text is removed, since a string replace could lead to erroneous string replacements, but there is some traffic on #1806 and it was a significant issue for our team in production.