### PR TITLE
Fix issue When ui-select is inside a modal popup, items do not show up properly.

### DIFF
--- a/dist/select.js
+++ b/dist/select.js
@@ -842,7 +842,7 @@ uis.controller('uiSelectCtrl',
           return true;
         };
 
-    ctrl.searchInput.css('width', '10px');
+    ctrl.searchInput.css('width', inputWidth+'px');
     $timeout(function() { //Give tags time to render correctly
       if (sizeWatch === null && !updateIfVisible(calculateContainerWidth())) {
         sizeWatch = $scope.$watch(function() {


### PR DESCRIPTION
Remove the hard-coded 10px in the input search.
Fix issue #1126