### PR TITLE
BugFix: removing the label when new tag is clicked on

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -386,8 +386,10 @@ uis.controller('uiSelectCtrl',
       if (!item || !_isItemDisabled(item)) {
         // if click is made on existing item, prevent from tagging, ctrl.search does not matter
         ctrl.clickTriggeredSelect = false;
-        if($event && ($event.type === 'click' || $event.type === 'touchend') && item)
+        if($event && ($event.type === 'click' || $event.type === 'touchend') && item){
           ctrl.clickTriggeredSelect = true;
+          item = item.replace(ctrl.taggingLabel,'').trim();
+        }
 
         if(ctrl.tagging.isActivated && ctrl.clickTriggeredSelect === false) {
           // if taggingLabel is disabled and item is undefined we pull from ctrl.search


### PR DESCRIPTION
### TL;DR
When creating a new tag and clicking to add it to multi tag select, the tag remains named "Tag(new)" with the label even after it's created.
How to reproduce:
go to this [plunker](http://plnkr.co/edit/?p=preview)
Create a new tag by typing something then you will see the label added in the select options if you select it via keyboard enter the label vanishes, & the tag is added without the label 
but ...
if you select via mouse click the label stays...


### description
Desired outcome: When you type in "Tag" the selection screen will show "Tag(new)". When you select "Tag(new)", the actual tag will be called "Tag".
Actual outcome: The created tag is still called "Tag(new)".
### images
the bug!
![image](https://cloud.githubusercontent.com/assets/13344801/26172228/5d13ae44-3b50-11e7-8b46-61b98cd02383.png)
the desired outcome!
![image](https://cloud.githubusercontent.com/assets/13344801/26172248/6ab2ef42-3b50-11e7-9bc3-e25e6a831c61.png)
the label added to the select option.
![image](https://cloud.githubusercontent.com/assets/13344801/26172267/8103b966-3b50-11e7-8f4c-00d8c2a841be.png)

thanks!

