### PR TITLE
Proposal of a way to change the class and style of tags, selected choice and available choices

### DIFF
--- a/src/bootstrap/choices.tpl.html
+++ b/src/bootstrap/choices.tpl.html
@@ -5,7 +5,7 @@
     <div ng-show="$select.isGrouped" class="ui-select-choices-group-label dropdown-header" ng-bind="$group.name"></div>
     <div ng-attr-id="ui-select-choices-row-{{ $select.generatedId }}-{{$index}}" class="ui-select-choices-row"
     ng-class="{active: $select.isActive(this), disabled: $select.isDisabled(this)}" role="option">
-      <span class="ui-select-choices-row-inner"></span>
+      <span class="ui-select-choices-row-inner" ng-class="$select.choiceClass(this)" ng-style="$select.choiceStyle(this)"></span>
     </div>
   </li>
 </ul>

--- a/src/bootstrap/match-multiple.tpl.html
+++ b/src/bootstrap/match-multiple.tpl.html
@@ -6,7 +6,8 @@
       type="button"
       ng-disabled="$select.disabled"
       ng-click="$selectMultiple.activeMatchIndex = $index;"
-      ng-class="{'btn-primary':$selectMultiple.activeMatchIndex === $index, 'select-locked':$select.isLocked(this, $index)}"
+      ng-class="$select.matchClass(this, $index, {'btn-primary':$selectMultiple.activeMatchIndex === $index, 'select-locked':$select.isLocked(this, $index)})"
+      ng-style="$select.matchStyle(this, $index)"
       ui-select-sort="$select.selected">
         <span class="close ui-select-match-close" ng-hide="$select.disabled" ng-click="$selectMultiple.removeChoice($index)">&nbsp;&times;</span>
         <span uis-transclude-append></span>

--- a/src/bootstrap/match.tpl.html
+++ b/src/bootstrap/match.tpl.html
@@ -1,6 +1,8 @@
 <div class="ui-select-match" ng-hide="$select.open && $select.searchEnabled" ng-disabled="$select.disabled" ng-class="{'btn-default-focus':$select.focus}">
   <span tabindex="-1"
       class="btn btn-default form-control ui-select-toggle"
+      ng-class="$select.matchClass(this)"
+      ng-style="$select.matchStyle(this)"
       aria-label="{{ $select.baseTitle }} activate"
       ng-disabled="$select.disabled" 
       ng-click="$select.activate()"

--- a/src/select2/choices.tpl.html
+++ b/src/select2/choices.tpl.html
@@ -3,7 +3,9 @@
     <div ng-show="$select.choiceGrouped($group)" class="ui-select-choices-group-label select2-result-label" ng-bind="$group.name"></div>
     <ul
       id="ui-select-choices-{{ $select.generatedId }}" ng-class="{'select2-result-sub': $select.choiceGrouped($group), 'select2-result-single': !$select.choiceGrouped($group) }">
-      <li role="option" ng-attr-id="ui-select-choices-row-{{ $select.generatedId }}-{{$index}}" class="ui-select-choices-row" ng-class="{'select2-highlighted': $select.isActive(this), 'select2-disabled': $select.isDisabled(this)}">
+      <li role="option" ng-attr-id="ui-select-choices-row-{{ $select.generatedId }}-{{$index}}" class="ui-select-choices-row"
+          ng-class="$select.choiceClass(this, {'select2-highlighted': $select.isActive(this), 'select2-disabled': $select.isDisabled(this)})"
+          ng-style="$select.choiceStyle(this)">
         <div class="select2-result-label ui-select-choices-row-inner"></div>
       </li>
     </ul>

--- a/src/select2/match-multiple.tpl.html
+++ b/src/select2/match-multiple.tpl.html
@@ -5,8 +5,8 @@
 -->
 <span class="ui-select-match">
   <li class="ui-select-match-item select2-search-choice" ng-repeat="$item in $select.selected track by $index"
-      ng-class="{'select2-search-choice-focus':$selectMultiple.activeMatchIndex === $index, 'select2-locked':$select.isLocked(this, $index)}"
-      ui-select-sort="$select.selected">
+      ng-class="$select.matchClass(this, $index,  {'select2-search-choice-focus':$selectMultiple.activeMatchIndex === $index, 'select2-locked':$select.isLocked(this, $index)})"
+      ng-style="$select.matchStyle(this, $index)" ui-select-sort="$select.selected">
       <span uis-transclude-append></span>
       <a href="javascript:;" class="ui-select-match-close select2-search-choice-close" ng-click="$selectMultiple.removeChoice($index)" tabindex="-1"></a>
   </li>

--- a/src/select2/match.tpl.html
+++ b/src/select2/match.tpl.html
@@ -4,7 +4,8 @@
   do not work: [class^="select2-choice"]
 -->
 <a class="select2-choice ui-select-match"
-   ng-class="{'select2-default': $select.isEmpty()}"
+   ng-class="$select.matchClass(this, null, {'select2-default': $select.isEmpty()})"
+   ng-style="$select.matchStyle(this)"
    ng-click="$select.toggle($event)" aria-label="{{ $select.baseTitle }} select">
   <span ng-show="$select.isEmpty()" class="select2-chosen">{{$select.placeholder}}</span>
   <span ng-hide="$select.isEmpty()" class="select2-chosen" ng-transclude></span>

--- a/src/selectize/choices.tpl.html
+++ b/src/selectize/choices.tpl.html
@@ -3,7 +3,8 @@
   <div class="ui-select-choices-content selectize-dropdown-content">
     <div class="ui-select-choices-group optgroup">
       <div ng-show="$select.isGrouped" class="ui-select-choices-group-label optgroup-header" ng-bind="$group.name"></div>
-      <div role="option" class="ui-select-choices-row" ng-class="{active: $select.isActive(this), disabled: $select.isDisabled(this)}">
+      <div role="option" class="ui-select-choices-row" ng-class="$select.choiceClass(this, {active: $select.isActive(this), disabled: $select.isDisabled(this)})"
+          ng-style="$select.choiceStyle(this)">
         <div class="option ui-select-choices-row-inner" data-selectable></div>
       </div>
     </div>

--- a/src/selectize/match-multiple.tpl.html
+++ b/src/selectize/match-multiple.tpl.html
@@ -1,7 +1,8 @@
 <div class="ui-select-match" data-value
      ng-repeat="$item in $select.selected track by $index"
      ng-click="$selectMultiple.activeMatchIndex = $index;"
-     ng-class="{'active':$selectMultiple.activeMatchIndex === $index}"
+     ng-class="$select.matchClass(this, $index, {'active':$selectMultiple.activeMatchIndex === $index})"
+     ng-style="$select.matchStyle(this, $index)"
      ui-select-sort="$select.selected">
   <span class="ui-select-match-item"
         ng-class="{'select-locked':$select.isLocked(this, $index)}">

--- a/src/uiSelectChoicesDirective.js
+++ b/src/uiSelectChoicesDirective.js
@@ -59,6 +59,8 @@ uis.directive('uiSelectChoices',
         $select.onHighlightCallback = attrs.onHighlight;
         $select.minimumInputLength = parseInt(attrs.minimumInputLength) || 0;
         $select.dropdownPosition = attrs.position ? attrs.position.toLowerCase() : uiSelectConfig.dropdownPosition;
+        $select.choiceClassExpression = attrs.uiChoiceClass;
+        $select.choiceStyleExpression = attrs.uiChoiceStyle;
 
         scope.$watch('$select.search', function(newValue) {
           if(newValue && !$select.open && $select.multiple) $select.activate(false, true);

--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -42,6 +42,10 @@ uis.controller('uiSelectCtrl',
   ctrl.tagging = {isActivated: false, fct: undefined};
   ctrl.taggingTokens = {isActivated: false, tokens: undefined};
   ctrl.lockChoiceExpression = undefined; // Initialized inside uiSelectMatch directive link function
+  ctrl.matchClassExpression = undefined; // Initialized inside uiSelectMatch directive link function
+  ctrl.matchStyleExpression = undefined; // Initialized inside uiSelectMatch directive link function
+  ctrl.choiceClassExpression = undefined; // Initialized inside uiSelectChoices directive link function
+  ctrl.choiceStyleExpression = undefined; // Initialized inside uiSelectChoices directive link function
   ctrl.clickTriggeredSelect = false;
   ctrl.$filter = $filter;
   ctrl.$element = $element;
@@ -518,6 +522,68 @@ uis.controller('uiSelectCtrl',
       return isLocked;
     };
   }
+
+  ctrl.matchClass = function(itemScope, itemIndex, deflt) {
+    deflt = deflt || {};
+    if(!ctrl.matchClassExpression) return deflt;
+    var context = {};
+    if(typeof itemIndex === 'number'){
+      context.$match = {
+        active: itemScope.$selectMultiple.activeMatchIndex == itemIndex,
+        locked: ctrl.isLocked(itemScope, itemIndex),
+      };
+    }
+    var cls = itemScope.$eval(ctrl.matchClassExpression, context);
+    if(typeof cls === 'string'){
+      cls.split(/\s+/).forEach(function(c){
+        deflt[c] = true;
+      });
+    }else if(cls){
+      for(var c in cls) deflt[c] = cls[c];
+    }
+    return deflt;
+  };
+
+  ctrl.matchStyle = function(itemScope, itemIndex) {
+    if(!ctrl.matchStyleExpression) return {};
+    var context = {};
+    if(typeof itemIndex === 'number'){
+      context.$match = {
+        active: itemScope.$selectMultiple.activeMatchIndex == itemIndex,
+        locked: ctrl.isLocked(itemScope, itemIndex),
+      };
+    }
+    return itemScope.$eval(ctrl.matchStyleExpression, context) || {};
+  };
+
+  ctrl.choiceClass = function(itemScope, deflt) {
+    deflt = deflt || {};
+    if(!ctrl.choiceClassExpression) return deflt;
+    var context = {};
+    context.$choice = {
+      active: ctrl.isActive(itemScope),
+      disabled: ctrl.isDisabled(itemScope),
+    };
+    var cls = itemScope.$eval(ctrl.choiceClassExpression, context);
+    if(typeof cls === 'string'){
+      cls.split(/\s+/).forEach(function(c){
+        deflt[c] = true;
+      });
+    }else if(cls){
+      for(var c in cls) deflt[c] = cls[c];
+    }
+    return deflt;
+  };
+
+  ctrl.choiceStyle = function(itemScope) {
+    if(!ctrl.choiceStyleExpression) return {};
+    var context = {};
+    context.$choice = {
+      active: ctrl.isActive(itemScope),
+      disabled: ctrl.isDisabled(itemScope),
+    };
+    return itemScope.$eval(ctrl.choiceStyleExpression, context) || {};
+  };
 
 
   var sizeWatch = null;

--- a/src/uiSelectMatchDirective.js
+++ b/src/uiSelectMatchDirective.js
@@ -17,6 +17,8 @@ uis.directive('uiSelectMatch', ['uiSelectConfig', function(uiSelectConfig) {
     },
     link: function(scope, element, attrs, $select) {
       $select.lockChoiceExpression = attrs.uiLockChoice;
+      $select.matchClassExpression = attrs.uiMatchClass;
+      $select.matchStyleExpression = attrs.uiMatchStyle;
       attrs.$observe('placeholder', function(placeholder) {
         $select.placeholder = placeholder !== undefined ? placeholder : uiSelectConfig.placeholder;
       });


### PR DESCRIPTION
Despite having been discussed, no way to change tag colors has never been implemented yet. Therefore I've implemented a method for my usage, and tried to make it as generic and simple as possible. Here is my proposal.

I've created 4 new attributes:
- `ui-match-class` and `ui-match-style` in `<ui-select-match>` in order to change the class and style of the tags (multiple case) or the selected choice (single case). They can use the scope variables `$match.active` and `$match.locked` to have a more flexible behavior.
- `ui-choice-class` and `ui-choice-style` in `<ui-select-choice>` in order to change the class and style of the available choices. They can use the scope variables `$choice.active` and `$choice.disabled` to have a more flexible behavior.

It is totally retro-compatible (the behavior is unchanged if they are absent), and compatible with every theme (except for the selected choice with the serialize theme). It is especially largely compatible with bootstrap tags, with whom the `btn-xxx` classes can be used. It is from far simple enough for most usages.

All features can be tested in this plunkr: http://plnkr.co/edit/gq04wJ9C0iaaLA87Pfxg