### PR TITLE
Remove inline javascript causing CSP errors

### DIFF
--- a/src/select2/match-multiple.tpl.html
+++ b/src/select2/match-multiple.tpl.html
@@ -8,6 +8,6 @@
       ng-class="{'select2-search-choice-focus':$selectMultiple.activeMatchIndex === $index, 'select2-locked':$select.isLocked(this, $index)}"
       ui-select-sort="$select.selected">
       <span uis-transclude-append></span>
-      <a href="javascript:;" class="ui-select-match-close select2-search-choice-close" ng-click="$selectMultiple.removeChoice($index)" tabindex="-1"></a>
+      <a class="ui-select-match-close select2-search-choice-close" ng-click="$selectMultiple.removeChoice($index)" tabindex="-1"></a>
   </li>
 </span>


### PR DESCRIPTION
This PR removes inline javascript call in the select2 template that causes CSP error messages when 'unsafe-inline' is not allowed via CSP headers.

Related to https://github.com/angular-ui/ui-select/issues/1218