### PR TITLE
Refactoring the behavior of "as" combined with "track by"

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -33,6 +33,8 @@ uis.controller('uiSelectCtrl',
   ctrl.focus = false;
   ctrl.disabled = false;
   ctrl.selected = undefined;
+  ctrl.resolved = undefined; //True if the selected value has been resolved against the choices
+  ctrl.nextResolved = undefined; //The value of resolved at the next $render call
 
   ctrl.dropdownPosition = 'auto';
 

--- a/src/uiSelectMultipleDirective.js
+++ b/src/uiSelectMultipleDirective.js
@@ -9,8 +9,10 @@ uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelec
           $select = $scope.$select,
           ngModel;
 
-      if (angular.isUndefined($select.selected))
+      if (angular.isUndefined($select.selected)){
         $select.selected = [];
+        $select.resolved = [];
+      }
 
       //Wait for link fn to inject it
       $scope.$evalAsync(function(){ ngModel = $scope.ngModel; });
@@ -46,6 +48,7 @@ uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelec
         locals[$select.parserResult.itemName] = removedChoice;
 
         $select.selected.splice(index, 1);
+        $select.resolved.splice(index, 1);
         ctrl.activeMatchIndex = -1;
         $select.sizeSearchInput();
 
@@ -109,40 +112,75 @@ uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelec
         var data = $select.parserResult && $select.parserResult.source (scope, { $select : {search:''}}), //Overwrite $search
             locals = {},
             result;
-        if (!data) return inputValue;
-        var resultMultiple = [];
-        var checkFnMultiple = function(list, value){
-          if (!list || !list.length) return;
-          for (var p = list.length - 1; p >= 0; p--) {
-            locals[$select.parserResult.itemName] = list[p];
-            result = $select.parserResult.modelMapper(scope, locals);
-            if($select.parserResult.trackByExp){
-                var propsItemNameMatches = /(\w*)\./.exec($select.parserResult.trackByExp);
-                var matches = /\.([^\s]+)/.exec($select.parserResult.trackByExp);
-                if(propsItemNameMatches && propsItemNameMatches.length > 0 && propsItemNameMatches[1] == $select.parserResult.itemName){
-                  if(matches && matches.length>0 && result[matches[1]] == value[matches[1]]){
-                      resultMultiple.unshift(list[p]);
-                      return true;
-                  }
-                }
-            }
-            if (angular.equals(result,value)){
-              resultMultiple.unshift(list[p]);
-              return true;
+        var resultMultiple = [], resolved = [];
+        $select.nextResolved = resolved; // resolved for the next $render call
+        setTimeout(function(){
+          $select.nextResolved = undefined;
+        });
+        if (!inputValue) return resultMultiple; //If ngModel was undefined
+        // compute the keys of an item, to match against the value
+        var keyOfItem = function(item){
+          locals[$select.parserResult.itemName] = item;
+          return {
+            item: item,
+            model: $select.parserResult.modelMapper(scope, locals),
+            trackBy: $select.parserResult.trackByMapper && $select.parserResult.trackByMapper(scope, locals),
+          };
+        };
+        // compare the keys of the value and the item
+        var valueMatchItem = function(value, item){
+          // check the following cases:
+          // * value is equals to item (formatted as a choice)
+          // * value is equals to item (formatted as a model)
+          // * the "track by" ids of value (formatted as a choice) and item are the same
+          // * the "track by" ids of value (formatted as a model) and item are the same
+          if(angular.equals(value.model, item.model) || angular.equals(value.model, item.item)) return true;
+          if($select.parserResult.trackByMapper){
+            if(value.trackBy === item.trackBy) return true;
+            if($select.parserResult.modelToTrackByMapper){
+              if(value.modelTotrackBy === item.trackBy) return true;
             }
           }
           return false;
         };
-        if (!inputValue) return resultMultiple; //If ngModel was undefined
-        for (var k = inputValue.length - 1; k >= 0; k--) {
+        // the list of resolved selected items with their keys
+        var selected = $select.selected.filter(function(item, index){
+          return $select.resolved[index];
+        }).map(keyOfItem);
+        // the list of choices with their keys, computed at the last moment
+        var search = data ? null : [];
+        for (var k = 0, i; k < inputValue.length; k++) {
+          // the keys of the value, to match against the items
+          locals[$select.parserResult.itemName] = inputValue[k];
+          var value = {
+            model: inputValue[k],
+            trackBy: $select.parserResult.trackByMapper && $select.parserResult.trackByMapper(scope, locals),
+            modelTotrackBy: $select.parserResult.modelToTrackByMapper && $select.parserResult.modelToTrackByMapper(scope, locals),
+          };
           //Check model array of currently selected items
-          if (!checkFnMultiple($select.selected, inputValue[k])){
-            //Check model array of all items available
-            if (!checkFnMultiple(data, inputValue[k])){
-              //If not found on previous lists, just add it directly to resultMultiple
-              resultMultiple.unshift(inputValue[k]);
+          for(i = selected.length - 1; i >= 0; i--){
+            if(valueMatchItem(value, selected[i])){
+              resultMultiple.push(selected[i].item);
+              resolved.push(true);
+              value = null;
+              break;
             }
           }
+          if(!value) continue;
+          //Check model array of all items available
+          if(!search) search = data.map(keyOfItem);
+          for(i = search.length - 1; i >= 0; i--){
+            if(valueMatchItem(value, search[i])){
+              resultMultiple.push(search[i].item);
+              resolved.push(true);
+              value = null;
+              break;
+            }
+          }
+          if(!value) continue;
+          //If not found on previous lists, just add it directly to resultMultiple
+          resultMultiple.push(inputValue[k]);
+          resolved.push(false);
         }
         return resultMultiple;
       });
@@ -169,6 +207,13 @@ uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelec
           }
         }
         $select.selected = ngModel.$viewValue;
+        if($select.nextResolved){
+          $select.resolved = $select.nextResolved;
+          $select.nextResolved = undefined;
+        }else{
+          $select.resolved = [];
+          $select.resolved.length = ngModel.$viewValue.length;
+        }
         $selectMultiple.refreshComponent();
         scope.$evalAsync(); //To force $digest
       };
@@ -178,6 +223,7 @@ uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelec
           return;
         }
         $select.selected.push(item);
+        $select.resolved.push(true);
         var locals = {};
         locals[$select.parserResult.itemName] = item;
 

--- a/src/uisRepeatParserService.js
+++ b/src/uisRepeatParserService.js
@@ -60,21 +60,91 @@ uis.service('uisRepeatParser', ['uiSelectMinErr','$parse', function(uiSelectMinE
 
     // Try to compute modelToTrackByMapper, such that 
     // modelToTrackByMapper on modelMapper is equivalent to trackByMapper
-    // It makes sense when match[1] is a prefix of match[6]
-    var itemName = match[4] || match[2],
-        modelToTrackByMapper;
-    if(!match[1] || !match[6]){
-      modelToTrackByMapper = null;
-    }else if(match[1] === match[6]){
-      modelToTrackByMapper = $parse(itemName);
-    }else if(match[6].substring(0, match[1].length + 1) === match[1] + '.'){
-      try{
-        modelToTrackByMapper = $parse(itemName + '.' + match[6].substring(match[1].length + 1));
-      }catch(e){
+    // Only in the case where the "as" expression is used in the "track by" exrepssion
+    var itemName = match[4] || match[2], 
+        trackByMapper = null, 
         modelToTrackByMapper = null;
+    if(match[6]){
+      // returns all occurences of expr in str as a variable
+      var exprIsUsed = function(str, expr){
+        // look for occurences of expr in str
+        var positions = [], 
+            i = 0;
+        while(true){
+          i = str.indexOf(expr, i);
+          if(i < 0) break;
+          positions.push([i, i + expr.length]);
+          i += expr.length;
+        }
+        if(!positions.length) return positions;
+        // Parse str to look for real occurences of expr as variable
+        var backslash = false, 
+            string = null, 
+            previous = '', 
+            found = [];
+        var strstart = /['"]/, 
+            space = /\s/, 
+            letter = /[a-z]/, 
+            noprev = /[\w$]|\s*\./, 
+            varchar = /[\w$]/;
+        for(i = 0; i < str.length; i++){
+          if(positions[0][0] == i){
+            // expr is escaped, part of a string or inside a longer path
+            if(backslash || string || noprev.test(previous)){
+              positions.shift();
+              if(!positions.length) return found;
+            }
+          }else if(positions[0][1] == i){
+            // check that the next character is not a variable character
+            if(!varchar.test(str[i])){
+              found.push(positions[0]);
+            }
+            positions.shift();
+            if(!positions.length) return found;
+          }
+          if(backslash) backslash = false; // this character is escaped
+          else if(str[i] === '\\') backslash = true; // next character is escaped
+          else if(string){ // inside a string
+            if(str[i] === string) string = null; // last character of this string
+          }else if(strstart.test(str[i])){ // first character of a string
+            string = str[i];
+            previous = '';
+          }else if(space.test(str[i])){ // a space, can be end of an operator like "in" or "typeof"
+            if(letter.test(previous)) previous = '';
+          }else previous = str[i]; // another character
+        }
+        // expr is at the end
+        found.push(positions[0]);
+        return found;
+      };
+      // if $index is used in "track by" expression, it cannot be used for matching
+      if(!exprIsUsed(match[6], '$index').length){
+        trackByMapper = $parse(match[6]);
+        // if $index is used in "as" expression, it cannot be used for matching
+        if(match[1] && !exprIsUsed(match[1], '$index').length){
+          // Check that every occurrence of itemName in the "track by" expresison is inside a copy of the "as" expression
+          // and replace every occurence of the "as" expression in the "track by" by itemName
+          var itempos = exprIsUsed(match[6], itemName);
+          var modelpos = exprIsUsed(match[6], match[1]);
+          var parts = [], 
+              index = 0;
+          while(modelpos.length){
+            // this occurence of itemName is inside this copy of "as" expression
+            if(itempos.length && itempos[0][0] >= modelpos[0][0] && itempos[0][1] <= modelpos[0][1]){
+              itempos.shift();
+            }else{ // there is not other occurence of itemName inside this copy of "as" expression
+              parts.push(match[6].substring(index, modelpos[0][0]), itemName);
+              index = modelpos[0][1];
+              modelpos.shift();
+            }
+          }
+          parts.push(match[6].substring(index, match[6].length));
+          if(!itempos.length){ // all occurences of itemName were inside a copy of the "as" expression
+            try{ modelToTrackByMapper = $parse(parts.join(''));
+            }catch(e){} // ignore errors of parsing in absurdly complex case
+          }
+        }
       }
-    }else{
-      modelToTrackByMapper = null;
     }
 
     return {
@@ -83,7 +153,7 @@ uis.service('uisRepeatParser', ['uiSelectMinErr','$parse', function(uiSelectMinE
       source: $parse(source),
       filters: filters,
       trackByExp: match[6],
-      trackByMapper: match[6] && $parse(match[6]),
+      trackByMapper: trackByMapper,
       modelToTrackByMapper: modelToTrackByMapper,
       modelMapper: $parse(match[1] || itemName),
       repeatExpression: function (grouped) {


### PR DESCRIPTION
This pull solves most problem due to the combined usage of "as" and "track by" (#1762, #1756, ...), and most problems of the selected items not being updated by the choices items (#1989, ...). It solves the problem noticed here: https://github.com/angular-ui/ui-select/wiki/ui-select-choices#warning-select-as-and-track-by
This pull is compatible with the old behavior.

For instance, the following expressions are now valid and will result in a perfect matching between the model and the choices items in both single and multiple cases (and are tested):
* `repeat="person.email as person in people track by person.email"`
* `repeat="item.deep.person as item in peopleDeep"`
* `repeat="item.deep as item in peopleDeep track by item.deep.person.email"`
* `repeat="choice.value.index as choice in list track by choice.value.index"`
* `repeat="choice in list track by 2 * choice.index + 1"`
* `repeat="choice.value.index as choice in list track by Math.pow(choice.value.index, 2) - Math.ceil(1+choice.value.index/2)"`
* `repeat="Math.floor(2+Math.sqrt(choice)) as choice in list track by 6*Math.floor(2+Math.sqrt(choice))-2"`

## Cause of the issues

Currently, the matching between the model and the choices are performed as such:
* in single mode, each choice is transformed into model (the "as" expression) and is compared to the model by `===`
* in multiple mode, each choice is transformed into model (the "as" expression) and is first compared by its "track by" value in the simple case `... track by itemName.prop`, and second compared to the model by `angular.equals`

These two behaviors are both pretty approximate (for instance, `item in list track by item.id` is not even treated in single mode).
Moreover, the model values won't be updated if the refresh function is asynchronous.

## Solution

First, the repeat parser has two new properties
* `$select.parserResult.trackByMapper`: a function that turns an item into a "track by" value (null if "track by" is absent or is using `$index`)
* `$select.parserResult.modelToTrackByMapper`: a function that turns a model (as obtained by `$select.parserResult.modelMapper(item)`) in a "track by" (null if impossible).

So `modelToTrackByMapper(modelMapper(item)) === trackByMapper(item)` when those two functions exist.

Second, a `$select.resolved` property (boolean in single mode, array of booleans is multiple mode) is created, saving which selected value has been matched to an item yet.

Third, at each formatting, the model (or each model item) is compared to the resolved selected items and the choices items with the following comparisons:
* `angular.equals(model, item)`
* `angular.equals(model, modelMapper(item))`
* `trackByMapper(model) === trackByMapper(item)`
* `modelToTrackByMapper(model) === trackByMapper(item)`

## Matching between "as" and "track by"

The algorithm is capable of finding the real occurrences of the "as" expression in the "track by" expression as a variable (it excludes the strings, prefixes, suffixes, ...) and will fail when another use of the item is found.
* `repeat="choice.index as choice in list track by (truc.choice.index || $choice.index || 'choice.index' != 'choice' && 's\'choice.index\'s' != 's\'choice\'s' && choice.index.toUpperCase() + choice.index || 'wrong')"` works and `modelToTrackByMapper('right') === "RIGHTright"` (fake occurrences of `choice.index` are not replaced)
* `repeat="choice.name as choice in list track by 2*choice.index+1"` does not work, because `choice.index` is not using `choice.name` (`modelToTrackByMapper = null`)


However, some unlikely corner cases can be problematic: for instance, `repeat="item.a + item.b as item in list track by item.a + item.b * 2"` will work and be interpreted as `(item.a + item.b) * 2`. But `repeat="(item.a + item.b) as item in list track by (item.a + item.b * 2)"` won't work.