### PR TITLE
fix(uiSelectMultiple): check if control key is pressed before calling KEY.isHorizontalMovement

### DIFF
--- a/src/uiSelectMultipleDirective.js
+++ b/src/uiSelectMultipleDirective.js
@@ -204,7 +204,7 @@ uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelec
         scope.$apply(function() {
           var processed = false;
           // var tagged = false; //Checkme
-          if(KEY.isHorizontalMovement(key)){
+          if(!KEY.isControl(e) && KEY.isHorizontalMovement(key)){
             processed = _handleMatchSelection(key);
           }
           if (processed  && key != KEY.TAB) {


### PR DESCRIPTION
fix(uiSelectMultiple): check if control key is pressed before calling KEY.isHorizontalMovement, breaks opt+cmd+right or left on some browsers, for instance Opera on XOS

change consistent with use of KEY.isControl(e) for other keydown events