### PR TITLE
fix(uiSelectCtrl): ensureHighlightVisible triggered with closed dropdown

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -158,7 +158,7 @@ uis.controller('uiSelectCtrl',
       } else {
         $timeout(function () {
           ctrl.focusSearchInput(initSearchValue);
-          if(!ctrl.tagging.isActivated && ctrl.items.length > 1) {
+          if(!ctrl.tagging.isActivated && ctrl.items.length > 1 && ctrl.open) {
             _ensureHighlightVisible();
           }
         });


### PR DESCRIPTION
This fix ensures that the dropdown actually is open before calling
_ensureHighlightVisible.

I didn't manage do reproduce the issue meaningfully in a test in the time I have available, but I think the change is quite obvious.

Here's a plunkr with the fix:
http://plnkr.co/edit/iV43PiaAzk0paO0ElZzT?p=preview

Fixes: #2050