### PR TITLE
fix highlight when using animate

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -137,6 +137,9 @@ uis.controller('uiSelectCtrl',
             ctrl.$animate.off('enter', container[0], animateHandler);
             $timeout(function () {
               ctrl.focusSearchInput(initSearchValue);
+              if(!ctrl.tagging.isActivated && ctrl.items.length > 1) {
+                _ensureHighlightVisible();
+              }
             });
           }
         };


### PR DESCRIPTION
when animate is used, the dropdown is not scrolled to the selected item - this commit calls "_ensureHighlightVisible" in this case, to fix it