### PR TITLE
fix(uiSelectHeaderGroupSelectableDirective): do not issue error if feature is disabled

### DIFF
--- a/src/uiSelectHeaderGroupSelectableDirective.js
+++ b/src/uiSelectHeaderGroupSelectableDirective.js
@@ -20,7 +20,9 @@ uis.directive('uiSelectHeaderGroupSelectable', ['$timeout', function($timeout) {
         if ($select.multiple && $select.groups) {
           return $element.querySelectorAll('.ui-select-choices-group-label');
         } else {
-          console.error('Use uiSelectHeaderGroupSelectable with no multiple uiSelect or without groupBy');
+          if(isEnabled()){
+            console.error('Use uiSelectHeaderGroupSelectable with no multiple uiSelect or without groupBy');
+          }
           return [];
         }
       }


### PR DESCRIPTION
My company uses wrapper around ui-select, so we always need `uiSelectHeaderGroupSelectableDirective` directive to exist on template even when ui-select is used for `single`/`no-groups` mode. In current implementation, if directive is disabled and other conditions do not pass, `console.error()` will be executed. That fix prevents error message to be shown for disabled directive.