### PR TITLE
fix(uiSelectHeaderGroupSelectable): css block not close

### DIFF
--- a/src/common.css
+++ b/src/common.css
@@ -297,6 +297,7 @@ body > .ui-select-bootstrap.open {
   padding: 5px 0;
   margin: 0;
   list-style: none;
+}
 
 .ui-select-bootstrap .ui-select-header-group-selectable:hover {
     background-color: #f5f5f5;


### PR DESCRIPTION
After merge pr #1998, build process doesn't work fine.

`gulp build` work but CSS block not close. I don't know why, the PR seems to be good :/.