### PR TITLE
Fixed creation of new-tag in IE-11

### DIFF
--- a/dist/select.js
+++ b/dist/select.js
@@ -1530,7 +1530,7 @@ uis.directive('uiSelectMatch', ['uiSelectConfig', function(uiSelectConfig) {
   }
 }]);
 
-uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelectMinErr, $timeout) {
+uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', '$$uisDebounce', function(uiSelectMinErr, $timeout, $$uisDebounce) {
   return {
     restrict: 'EA',
     require: ['^uiSelect', '^ngModel'],
@@ -1817,7 +1817,7 @@ uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelec
         return true;
       }
 
-      $select.searchInput.on('keyup', function(e) {
+      var setTagChoices = $$uisDebounce(function(e) {
 
         if ( ! KEY.isVerticalMovement(e.which) ) {
           scope.$evalAsync( function () {
@@ -1941,7 +1941,10 @@ uis.directive('uiSelectMultiple', ['uiSelectMinErr','$timeout', function(uiSelec
             }
           });
         }
-      });
+      }, 300);
+
+      $select.searchInput.on('keyup focus', setTagChoices);
+
       function _findCaseInsensitiveDupe(arr) {
         if ( arr === undefined || $select.search === undefined ) {
           return false;


### PR DESCRIPTION
IE was having issue with keyup event, as sometimes it lost input changes. Due to this,
- it creates empty tag
- Also auto-complete for new tag, skips last letter most of the times.
ex: Creating new tag as "Testing", but in autocomplete it shows "Testin"
Refer https://drive.google.com/file/d/1e6xK0DksZbIvqe71Fj_eyFadsorf7V17/view?usp=sharing

Update select.js, Delayed tag-choices formation on 'keyup' event by few milliseconds. This is working with IE-11 and chrome versions.

Note:
Currently only added changes in `dist/select.js` files. Please let me know in comments, whether shall I go ahead and update minified files too using `gulp`

Thanks
