### PR TITLE
Udpate karma version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "jquery": "~1.11",
     "jshint": "^2.9.1",
     "jshint-stylish": "~0.3.0",
-    "karma": "^0.12.16",
+    "karma": "^2.0.4",
     "karma-chrome-launcher": "^0.1.3",
     "karma-coverage": "~0.2",
     "karma-firefox-launcher": "~1.0",


### PR DESCRIPTION
When I was trying to use `gulp` to build the project, there is a dependency issue cased by outdated karma package:
```
Store.prototype.__proto__ = EventEmitter.prototype;
                                         ^
TypeError: Cannot read property 'prototype' of undefined
```
After updated karma version from 0.12.16 to 2.0.4 in package.json file, the error is gone when I build the project.